### PR TITLE
Create `trait Cast` with generic `upcast` and `downcast` methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub use self::app_info::AppInfo;
 pub use self::glib_container::GlibContainer;
 pub use self::error::{Error};
 pub use self::object::{
-    Downcast,
+    Cast,
     Object,
     Upcast,
 };


### PR DESCRIPTION
Remove `Upcast::upcast` making it a marker trait.
`Downcast` is not considered a general purpose trait, it's an implementation detail now.