### PR TITLE
Overhaul `GValue` bindings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ pub use self::permission::Permission;
 pub use self::source::{Continue, idle_add, timeout_add, timeout_add_seconds};
 pub use self::traits::FFIGObject;
 pub use types::Type;
-pub use value::{TypedValue, TypedValueMut, Value};
+pub use value::{TypedValue, Value};
 pub use self::date::{TimeVal, Time, Date, Year, Month, Weekday, Day};
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ pub use self::permission::Permission;
 pub use self::source::{Continue, idle_add, timeout_add, timeout_add_seconds};
 pub use self::traits::FFIGObject;
 pub use types::Type;
-pub use value::Value;
+pub use value::{TypedValue, TypedValueMut, Value};
 pub use self::date::{TimeVal, Time, Date, Year, Month, Weekday, Day};
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,8 @@ pub use self::object::{
 pub use self::permission::Permission;
 pub use self::source::{Continue, idle_add, timeout_add, timeout_add_seconds};
 pub use self::traits::FFIGObject;
-pub use self::value::{Value, ValuePublic};
 pub use types::Type;
+pub use value::Value;
 pub use self::date::{TimeVal, Time, Date, Year, Month, Weekday, Day};
 
 #[macro_use]
@@ -79,7 +79,7 @@ pub mod signal;
 pub mod source;
 pub mod traits;
 pub mod translate;
-mod value;
+pub mod value;
 
 pub mod types;
 pub mod date;

--- a/src/types.rs
+++ b/src/types.rs
@@ -61,6 +61,34 @@ pub trait StaticType {
     fn static_type() -> Type;
 }
 
+impl<'a, T: ?Sized + StaticType> StaticType for &'a T {
+    fn static_type() -> Type {
+        T::static_type()
+    }
+}
+
+macro_rules! builtin {
+    ($name:ident, $val:ident) => {
+        impl StaticType for $name {
+            fn static_type() -> Type {
+                Type::$val
+            }
+        }
+    }
+}
+
+builtin!(bool, Bool);
+builtin!(i8, I8);
+builtin!(u8, U8);
+builtin!(i32, I32);
+builtin!(u32, U32);
+builtin!(i64, I64);
+builtin!(u64, U64);
+builtin!(f32, F32);
+builtin!(f64, F64);
+builtin!(str, String);
+builtin!(String, String);
+
 pub trait InstanceType {
     fn instance_type(&self) -> Type;
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -23,10 +23,10 @@ pub enum Type {
     I32,
     /// The fundamental type corresponding to `u32`
     U32,
-    /// The fundamental type corresponding to `isize`
-    ISize,
-    /// The fundamental type corresponding to `usize`
-    USize,
+    /// The fundamental type corresponding to C `long`
+    ILong,
+    /// The fundamental type corresponding to C `unsigned long`
+    ULong,
     /// The fundamental type corresponding to `i64`
     I64,
     /// The fundamental type corresponding to `u64`
@@ -115,8 +115,8 @@ impl FromGlib<glib_ffi::GType> for Type {
             gobject_ffi::G_TYPE_BOOLEAN => Bool,
             gobject_ffi::G_TYPE_INT => I32,
             gobject_ffi::G_TYPE_UINT => U32,
-            gobject_ffi::G_TYPE_LONG => ISize,
-            gobject_ffi::G_TYPE_ULONG => USize,
+            gobject_ffi::G_TYPE_LONG => ILong,
+            gobject_ffi::G_TYPE_ULONG => ULong,
             gobject_ffi::G_TYPE_INT64 => I64,
             gobject_ffi::G_TYPE_UINT64 => U64,
             gobject_ffi::G_TYPE_ENUM => BaseEnum,
@@ -148,8 +148,8 @@ impl ToGlib for Type {
             Bool => gobject_ffi::G_TYPE_BOOLEAN,
             I32 => gobject_ffi::G_TYPE_INT,
             U32 => gobject_ffi::G_TYPE_UINT,
-            ISize => gobject_ffi::G_TYPE_LONG,
-            USize => gobject_ffi::G_TYPE_ULONG,
+            ILong => gobject_ffi::G_TYPE_LONG,
+            ULong => gobject_ffi::G_TYPE_ULONG,
             I64 => gobject_ffi::G_TYPE_INT64,
             U64 => gobject_ffi::G_TYPE_UINT64,
             BaseEnum => gobject_ffi::G_TYPE_ENUM,

--- a/src/value.rs
+++ b/src/value.rs
@@ -73,7 +73,7 @@ use std::ops::{Deref, DerefMut};
 
 use object::{Downcast, IsA, Object};
 use translate::*;
-use types::StaticType;
+use types::{StaticType, Type};
 
 use glib_ffi;
 use gobject_ffi;
@@ -122,6 +122,22 @@ impl Value {
            else {
                None
            }
+        }
+    }
+
+    /// Returns the type of the value.
+    pub fn type_(&self) -> Type {
+        unsafe {
+            // FIXME: make this safe by making GValue::g_type public
+            let type_ = *(&*self.0 as *const gobject_ffi::GValue as *const glib_ffi::GType);
+            from_glib(type_)
+        }
+    }
+
+    /// Returns whether `Value`s of type `src` can be transformed to type `dst`.
+    pub fn type_transformable(src: Type, dst: Type) -> bool {
+        unsafe {
+            from_glib(gobject_ffi::g_value_type_transformable(src.to_glib(), dst.to_glib()))
         }
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -179,6 +179,13 @@ impl<'a, T: FromValueOptional + SetValue> TypedValueMut<'a, T> {
         unsafe { SetValueOptional::set_value_optional(self.0, value) }
     }
 
+    /// Sets the value to `None`.
+    ///
+    /// This method is only available for types that support a `None` value.
+    pub fn set_none(&mut self) where T: SetValueOptional {
+        unsafe { T::set_value_optional(self.0, None) }
+    }
+
     /// Sets the value.
     pub fn set_some<'x, U: ?Sized>(&mut self, value: &'x U)
     where T: Borrow<U>, &'x U: SetValue {

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,324 +1,329 @@
-// Copyright 2013-2015, The Gtk-rs Project Developers.
+// Copyright 2013-2016, The Gtk-rs Project Developers.
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
+use std::borrow::Borrow;
+use std::fmt;
+use std::marker::PhantomData;
 use std::mem;
-use libc::c_char;
-use gobject_ffi;
-use super::{to_bool, to_gboolean};
-use types::Type;
+
+use object::{Downcast, IsA, Object};
 use translate::*;
+use types::StaticType;
 
-pub trait ValuePublic {
-    unsafe fn get(gvalue: &Value) -> Self;
-    unsafe fn set(&self, gvalue: &mut Value);
-}
+use glib_ffi;
+use gobject_ffi;
 
-pub struct Value {
-    inner: gobject_ffi::GValue,
-}
+/// A generic value capable of carrying various types.
+///
+/// Once created the type of the value can't be changed.
+///
+/// Some types (e.g. `String` and objects) support `None` values while others
+/// (e.g. numeric types) don't.
+pub struct Value(Box<gobject_ffi::GValue>);
 
 impl Value {
-    pub unsafe fn new() -> Value {
-        Value { inner: mem::zeroed() }
-    }
-
-    pub fn init(&mut self, _type: Type) {
-        unsafe { gobject_ffi::g_value_init(&mut self.inner, _type.to_glib()); }
-    }
-
-    pub fn reset(&mut self) {
-        unsafe { gobject_ffi::g_value_reset(&mut self.inner); }
-    }
-
-    pub unsafe fn unset(&mut self) {
-        gobject_ffi::g_value_unset(&mut self.inner)
-    }
-
-    pub fn strdup_value_contents(&mut self) -> Option<String> {
+    /// Tries to return a typed borrow of the value.
+    ///
+    /// Returns `Some(TypedValue<T>)` if the value carries a type corresponding
+    /// to `T` and `None` otherwise.
+    pub fn typed<T: FromValueOptional>(&self) -> Option<TypedValue<T>> {
         unsafe {
-            from_glib_full(gobject_ffi::g_strdup_value_contents(&mut self.inner) as *const c_char)
+            let ok = gobject_ffi::g_type_check_value_holds(mut_override(self.to_glib_none().0),
+                T::static_type().to_glib());
+            some_if(ok, || TypedValue(self, PhantomData))
         }
     }
 
-    pub unsafe fn set_boolean(&mut self, v_boolean: bool) {
-        gobject_ffi::g_value_set_boolean(&mut self.inner, to_gboolean(v_boolean))
+    /// Tries to return a typed mutable borrow of the value.
+    ///
+    /// Returns `Some(TypedValueMut<T>)` if the value carries a type
+    /// corresponding to `T` and `None` otherwise.
+    pub fn typed_mut<T: FromValueOptional + SetValue>(&mut self) -> Option<TypedValueMut<T>> {
+        unsafe {
+            let ok = gobject_ffi::g_type_check_value_holds(self.to_glib_none_mut().0,
+                T::static_type().to_glib());
+            some_if(ok, move || TypedValueMut(self, PhantomData))
+        }
     }
 
-    pub unsafe fn get_boolean(&self) -> bool {
-        to_bool(gobject_ffi::g_value_get_boolean(&self.inner))
+    /// Tries to get a value of type `T`.
+    ///
+    /// Returns `Some` if the type is correct and the value is not `None`.
+    ///
+    /// This function doesn't distinguish between type mismatches and correctly
+    /// typed `None` values. Use `typed` and `typed_mut` for that.
+    pub fn get<T: FromValueOptional>(&self) -> Option<T> {
+        self.typed::<T>().and_then(|v| v.get())
     }
+}
 
-    pub unsafe fn set_schar(&mut self, v_char: i8) {
-        gobject_ffi::g_value_set_schar(&mut self.inner, v_char)
-    }
-
-    pub unsafe fn get_schar(&self) -> i8 {
-        gobject_ffi::g_value_get_schar(&self.inner)
-    }
-
-    pub unsafe fn set_uchar(&mut self, v_uchar: u8) {
-        gobject_ffi::g_value_set_uchar(&mut self.inner, v_uchar)
-    }
-
-    pub unsafe fn get_uchar(&self) -> u8 {
-        gobject_ffi::g_value_get_uchar(&self.inner)
-    }
-
-    pub unsafe fn set_int(&mut self, v_int: i32) {
-        gobject_ffi::g_value_set_int(&mut self.inner, v_int)
-    }
-
-    pub unsafe fn get_int(&self) -> i32 {
-        gobject_ffi::g_value_get_int(&self.inner)
-    }
-
-    pub unsafe fn set_uint(&mut self, v_uint: u32) {
-        gobject_ffi::g_value_set_uint(&mut self.inner, v_uint)
-    }
-
-    pub unsafe fn get_uint(&self) -> u32 {
-        gobject_ffi::g_value_get_uint(&self.inner)
-    }
-
-    pub unsafe fn set_long(&mut self, v_long: i64) {
-        gobject_ffi::g_value_set_long(&mut self.inner, v_long as ::libc::c_long)
-    }
-
-    pub unsafe fn get_long(&self) -> i64 {
-        gobject_ffi::g_value_get_long(&self.inner) as i64
-    }
-
-    pub unsafe fn set_ulong(&mut self, v_ulong: u64) {
-        gobject_ffi::g_value_set_ulong(&mut self.inner, v_ulong as ::libc::c_ulong)
-    }
-
-    pub unsafe fn get_ulong(&self) -> u64 {
-        gobject_ffi::g_value_get_ulong(&self.inner) as u64
-    }
-
-    pub unsafe fn set_int64(&mut self, v_int64: i64) {
-        gobject_ffi::g_value_set_int64(&mut self.inner, v_int64)
-    }
-
-    pub unsafe fn get_int64(&self) -> i64 {
-        gobject_ffi::g_value_get_int64(&self.inner)
-    }
-
-    pub unsafe fn set_uint64(&mut self, v_uint64: u64) {
-        gobject_ffi::g_value_set_uint64(&mut self.inner, v_uint64)
-    }
-
-    pub unsafe fn get_uint64(&self) -> u64 {
-        gobject_ffi::g_value_get_uint64(&self.inner)
-    }
-
-    pub unsafe fn set_float(&mut self, v_float: f32) {
-        gobject_ffi::g_value_set_float(&mut self.inner, v_float)
-    }
-
-    pub unsafe fn get_float(&self) -> f32 {
-        gobject_ffi::g_value_get_float(&self.inner)
-    }
-
-    pub unsafe fn set_double(&mut self, v_double: f64) {
-        gobject_ffi::g_value_set_double(&mut self.inner, v_double)
-    }
-
-    pub unsafe fn get_double(&self) -> f64 {
-        gobject_ffi::g_value_get_double(&self.inner)
-    }
-
-    pub unsafe fn set_string(&mut self, v_string: &str) {
-        gobject_ffi::g_value_set_string(&mut self.inner, v_string.to_glib_none().0);
-    }
-
-    pub unsafe fn get_string(&self) -> Option<String> {
-        from_glib_none(gobject_ffi::g_value_get_string(&self.inner))
-    }
-
-    pub unsafe fn set_boxed<T>(&mut self, v_box: &T) {
-        gobject_ffi::g_value_set_boxed(&mut self.inner, ::std::mem::transmute(v_box))
-    }
-
-    /*pub fn take_boxed<T>(&self, v_box: &T) {
-        gobject_ffi::g_value_take_boxed(&mut self.inner, ::std::mem::transmute(v_box))
-    }*/
-
-    pub unsafe fn get_boxed<'r, T>(&'r self) -> &'r T {
-        ::std::mem::transmute(gobject_ffi::g_value_get_boxed(&self.inner))
-    }
-
-    /*pub unsafe fn dup_boxed<'r, T>(&'r self) -> &'r T {
-        ::std::mem::transmute(gobject_ffi::g_value_dup_boxed(&mut self.inner))
-    }*/
-
-    pub unsafe fn set_pointer<T>(&mut self, v_pointer: &T) {
-        gobject_ffi::g_value_set_pointer(&mut self.inner, ::std::mem::transmute(v_pointer))
-    }
-
-    pub unsafe fn get_pointer<'r, T>(&'r self) -> &'r T {
-        ::std::mem::transmute(gobject_ffi::g_value_get_pointer(&self.inner))
-    }
-
-    pub unsafe fn set_object<T>(&mut self, v_object: &T) {
-        gobject_ffi::g_value_set_object(&mut self.inner, ::std::mem::transmute(v_object))
-    }
-
-    pub unsafe fn get_object<'r, T>(&'r self) -> &'r T {
-        ::std::mem::transmute(gobject_ffi::g_value_get_object(&self.inner))
-    }
-
-    // FIXME shouldn't be like that
-    pub unsafe fn set_gtype(&mut self, v_gtype: Type) {
-        gobject_ffi::g_value_set_gtype(&mut self.inner, v_gtype.to_glib())
-    }
-
-    // FIXME shouldn't be like that
-    pub unsafe fn get_gtype(&self) -> Type {
-        from_glib(gobject_ffi::g_value_get_gtype(&self.inner))
-    }
-
-    pub unsafe fn set<T: ValuePublic>(&mut self, val: &T) {
-        val.set(self);
-    }
-
-    pub unsafe fn get<T: ValuePublic>(&self) -> T {
-        ValuePublic::get(self)
-    }
-
-    pub fn compatible(src_type: Type, dest_type: Type) -> bool {
-        unsafe { to_bool(gobject_ffi::g_value_type_compatible(src_type.to_glib(), dest_type.to_glib())) }
-    }
-
-    pub fn transformable(src_type: Type, dest_type: Type) -> bool {
-        unsafe { to_bool(gobject_ffi::g_value_type_transformable(src_type.to_glib(), dest_type.to_glib())) }
-    }
-
-    pub fn as_ptr(&self) -> *const gobject_ffi::GValue {
-        &self.inner
-    }
-
-    pub fn as_mut_ptr(&mut self) -> *mut gobject_ffi::GValue {
-        &mut self.inner
+impl Clone for Value {
+    fn clone(&self) -> Self {
+        unsafe {
+            // FIXME: make this safer by making GValue::g_type public
+            let type_ = *(&*self.0 as *const gobject_ffi::GValue as *const glib_ffi::GType);
+            let mut ret = Value(Box::new(mem::zeroed()));
+            gobject_ffi::g_value_init(ret.to_glib_none_mut().0, type_);
+            gobject_ffi::g_value_copy(self.to_glib_none().0, ret.to_glib_none_mut().0);
+            ret
+        }
     }
 }
 
 impl Drop for Value {
     fn drop(&mut self) {
-        unsafe { self.unset(); }
+        unsafe { gobject_ffi::g_value_unset(self.to_glib_none_mut().0) }
     }
 }
 
-impl ValuePublic for i32 {
-    unsafe fn get(gvalue: &Value) -> i32 {
-        gvalue.get_int()
-    }
-
-    unsafe fn set(&self, gvalue: &mut Value) {
-        gvalue.set_int(*self)
-    }
-}
-
-impl ValuePublic for u32 {
-    unsafe fn get(gvalue: &Value) -> u32 {
-        gvalue.get_uint()
-    }
-
-    unsafe fn set(&self, gvalue: &mut Value) {
-        gvalue.set_uint(*self)
-    }
-}
-
-impl ValuePublic for i64 {
-    unsafe fn get(gvalue: &Value) -> i64 {
-        gvalue.get_int64()
-    }
-
-    unsafe fn set(&self, gvalue: &mut Value) {
-        gvalue.set_int64(*self)
-    }
-}
-
-impl ValuePublic for u64 {
-    unsafe fn get(gvalue: &Value) -> u64 {
-        gvalue.get_uint64()
-    }
-
-    unsafe fn set(&self, gvalue: &mut Value) {
-        gvalue.set_uint64(*self)
-    }
-}
-
-impl ValuePublic for bool {
-    unsafe fn get(gvalue: &Value) -> bool {
-        gvalue.get_boolean()
-    }
-
-    unsafe fn set(&self, gvalue: &mut Value) {
-        gvalue.set_boolean(*self)
-    }
-}
-
-impl ValuePublic for i8 {
-    unsafe fn get(gvalue: &Value) -> i8 {
-        gvalue.get_schar()
-    }
-
-    unsafe fn set(&self, gvalue: &mut Value) {
-        gvalue.set_schar(*self)
-    }
-}
-
-impl ValuePublic for u8 {
-    unsafe fn get(gvalue: &Value) -> u8 {
-        gvalue.get_uchar()
-    }
-
-    unsafe fn set(&self, gvalue: &mut Value) {
-        gvalue.set_uchar(*self)
-    }
-}
-
-impl ValuePublic for f32 {
-    unsafe fn get(gvalue: &Value) -> f32 {
-        gvalue.get_float()
-    }
-
-    unsafe fn set(&self, gvalue: &mut Value) {
-        gvalue.set_float(*self)
-    }
-}
-
-impl ValuePublic for f64 {
-    unsafe fn get(gvalue: &Value) -> f64 {
-        gvalue.get_double()
-    }
-
-    unsafe fn set(&self, gvalue: &mut Value) {
-        gvalue.set_double(*self)
-    }
-}
-
-impl ValuePublic for Type {
-    unsafe fn get(gvalue: &Value) -> Type {
-        gvalue.get_gtype()
-    }
-
-    unsafe fn set(&self, gvalue: &mut Value) {
-        gvalue.set_gtype(*self)
-    }
-}
-
-impl ValuePublic for String {
-    unsafe fn get(gvalue: &Value) -> String {
-        match gvalue.get_string() {
-            Some(s) => s,
-            None => String::new()
+impl fmt::Debug for Value {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        unsafe {
+            let s: String = from_glib_full(
+                gobject_ffi::g_strdup_value_contents(self.to_glib_none().0));
+            write!(f, "{}", s)
         }
     }
+}
 
-    unsafe fn set(&self, gvalue: &mut Value) {
-        gvalue.set_string(self.as_ref())
+impl<T: SetValueOptional> From<Option<T>> for Value {
+    fn from(value: Option<T>) -> Value {
+        unsafe {
+            let mut ret = Value::uninitialized();
+            gobject_ffi::g_value_init(ret.to_glib_none_mut().0, T::static_type().to_glib());
+            T::set_value_optional(&mut ret, value);
+            ret
+        }
     }
 }
+
+impl<T: SetValue> From<T> for Value {
+    fn from(value: T) -> Value {
+        unsafe {
+            let mut ret = Value::uninitialized();
+            gobject_ffi::g_value_init(ret.to_glib_none_mut().0, T::static_type().to_glib());
+            T::set_value(&mut ret, value);
+            ret
+        }
+    }
+}
+
+impl Uninitialized for Value {
+    unsafe fn uninitialized() -> Value {
+        Value(Box::new(mem::zeroed()))
+    }
+}
+
+impl<'a> ToGlibPtr<'a, *const gobject_ffi::GValue> for Value {
+    type Storage = &'a Value;
+
+    fn to_glib_none(&'a self) -> Stash<'a, *const gobject_ffi::GValue, Self> {
+        Stash(&*self.0, self)
+    }
+}
+
+impl<'a> ToGlibPtrMut<'a, *mut gobject_ffi::GValue> for Value {
+    type Storage = &'a mut Value;
+
+    fn to_glib_none_mut(&'a mut self) -> StashMut<'a, *mut gobject_ffi::GValue, Self> {
+        StashMut(&mut *self.0, self)
+    }
+}
+
+/// A typed borrow of a `Value`.
+pub struct TypedValue<'a, T>(&'a Value, PhantomData<*const T>);
+
+impl<'a, T: FromValueOptional> TypedValue<'a, T> {
+    /// Returns the value.
+    ///
+    /// Types that don't support a `None` value always return `Some`. See
+    /// `get_some`.
+    pub fn get(&self) -> Option<T> {
+        unsafe { T::from_value_optional(self.0) }
+    }
+
+    /// Returns the value.
+    ///
+    /// This method is only available for types that don't support a `None`
+    /// value.
+    pub fn get_some(&self) -> T where T: FromValue {
+        unsafe { T::from_value(self.0) }
+    }
+}
+
+pub struct TypedValueMut<'a, T>(&'a mut Value, PhantomData<*const T>);
+
+impl<'a, T: FromValueOptional + SetValue> TypedValueMut<'a, T> {
+    /// Returns the value.
+    ///
+    /// Types that don't support a `None` value always return `Some`. See
+    /// `get_some`.
+    pub fn get(&self) -> Option<T> {
+        unsafe { T::from_value_optional(self.0) }
+    }
+
+    /// Returns the value.
+    ///
+    /// This method is only available for types that don't support a `None`
+    /// value.
+    pub fn get_some(&self) -> T where T: FromValue {
+        unsafe { T::from_value(self.0) }
+    }
+
+    /// Sets the value.
+    ///
+    /// This method is only available for types that support a `None` value.
+    pub fn set<'x, U: ?Sized>(&mut self, value: Option<&'x U>)
+    where T: Borrow<U>, &'x U: SetValueOptional {
+        unsafe { SetValueOptional::set_value_optional(self.0, value) }
+    }
+
+    /// Sets the value.
+    pub fn set_some<'x, U: ?Sized>(&mut self, value: &'x U)
+    where T: Borrow<U>, &'x U: SetValue {
+        unsafe { SetValue::set_value(self.0, value) }
+    }
+}
+
+/// Extracts a value.
+///
+/// Types that don't support a `None` value always return `Some`.
+pub trait FromValueOptional: StaticType + Sized {
+    unsafe fn from_value_optional(&Value) -> Option<Self>;
+}
+
+/// Extracts a value.
+///
+/// Only implemented for types that don't support a `None` value.
+pub trait FromValue: FromValueOptional {
+    unsafe fn from_value(&Value) -> Self;
+}
+
+/// Sets a value.
+///
+/// Only implemented for types that support a `None` value.
+pub trait SetValueOptional: SetValue {
+    unsafe fn set_value_optional(&mut Value, Option<Self>);
+}
+
+/// Sets a value.
+pub trait SetValue: StaticType + Sized {
+    unsafe fn set_value(&mut Value, Self);
+}
+
+impl FromValueOptional for String {
+    unsafe fn from_value_optional(value: &Value) -> Option<Self> {
+        from_glib_none(gobject_ffi::g_value_get_string(value.to_glib_none().0))
+    }
+}
+
+impl<'a> SetValue for &'a str {
+    unsafe fn set_value(value: &mut Value, this: Self) {
+        gobject_ffi::g_value_take_string(value.to_glib_none_mut().0, this.to_glib_full())
+    }
+}
+
+impl<'a> SetValueOptional for &'a str {
+    unsafe fn set_value_optional(value: &mut Value, this: Option<Self>) {
+        gobject_ffi::g_value_take_string(value.to_glib_none_mut().0, this.to_glib_full())
+    }
+}
+
+impl SetValue for String {
+    unsafe fn set_value(value: &mut Value, this: Self) {
+        gobject_ffi::g_value_take_string(value.to_glib_none_mut().0, this.to_glib_full())
+    }
+}
+
+impl SetValueOptional for String {
+    unsafe fn set_value_optional(value: &mut Value, this: Option<Self>) {
+        gobject_ffi::g_value_take_string(value.to_glib_none_mut().0, this.to_glib_full())
+    }
+}
+
+impl<T: IsA<Object>> FromValueOptional for T {
+    unsafe fn from_value_optional(value: &Value) -> Option<Self> {
+        Option::<Object>::from_glib_full(gobject_ffi::g_value_dup_object(value.to_glib_none().0))
+            .map(|o| o.downcast_unchecked())
+    }
+}
+
+impl<T: IsA<Object>> SetValue for T {
+    unsafe fn set_value(value: &mut Value, this: Self) {
+        gobject_ffi::g_value_set_object(value.to_glib_none_mut().0, this.to_glib_none().0)
+    }
+}
+
+impl<T: IsA<Object>> SetValueOptional for T {
+    unsafe fn set_value_optional(value: &mut Value, this: Option<Self>) {
+        gobject_ffi::g_value_set_object(value.to_glib_none_mut().0, this.to_glib_none().0)
+    }
+}
+
+impl<'a, T: IsA<Object>> SetValue for &'a T {
+    unsafe fn set_value(value: &mut Value, this: Self) {
+        gobject_ffi::g_value_set_object(value.to_glib_none_mut().0, this.to_glib_none().0)
+    }
+}
+
+impl<'a, T: IsA<Object>> SetValueOptional for &'a T {
+    unsafe fn set_value_optional(value: &mut Value, this: Option<Self>) {
+        gobject_ffi::g_value_set_object(value.to_glib_none_mut().0, this.to_glib_none().0)
+    }
+}
+
+impl FromValueOptional for bool {
+    unsafe fn from_value_optional(value: &Value) -> Option<Self> {
+        Some(from_glib(gobject_ffi::g_value_get_boolean(value.to_glib_none().0)))
+    }
+}
+
+impl FromValue for bool {
+    unsafe fn from_value(value: &Value) -> Self {
+        from_glib(gobject_ffi::g_value_get_boolean(value.to_glib_none().0))
+    }
+}
+
+impl SetValue for bool {
+    unsafe fn set_value(value: &mut Value, this: Self) {
+        gobject_ffi::g_value_set_boolean(value.to_glib_none_mut().0, this.to_glib())
+    }
+}
+
+macro_rules! numeric {
+    ($name:ident, $get:ident, $set:ident) => {
+        impl FromValueOptional for $name {
+            unsafe fn from_value_optional(value: &Value) -> Option<Self> {
+                Some(gobject_ffi::$get(value.to_glib_none().0))
+            }
+        }
+
+        impl FromValue for $name {
+            unsafe fn from_value(value: &Value) -> Self {
+                gobject_ffi::$get(value.to_glib_none().0)
+            }
+        }
+
+        impl SetValue for $name {
+            unsafe fn set_value(value: &mut Value, this: Self) {
+                gobject_ffi::$set(value.to_glib_none_mut().0, this)
+            }
+        }
+
+        impl<'a> SetValue for &'a $name {
+            unsafe fn set_value(value: &mut Value, this: Self) {
+                gobject_ffi::$set(value.to_glib_none_mut().0, *this)
+            }
+        }
+    }
+}
+
+numeric!(i8, g_value_get_schar, g_value_set_schar);
+numeric!(u8, g_value_get_uchar, g_value_set_uchar);
+numeric!(i32, g_value_get_int, g_value_set_int);
+numeric!(u32, g_value_get_uint, g_value_set_uint);
+numeric!(i64, g_value_get_int64, g_value_set_int64);
+numeric!(u64, g_value_get_uint64, g_value_set_uint64);
+numeric!(f32, g_value_get_float, g_value_set_float);
+numeric!(f64, g_value_get_double, g_value_set_double);

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -63,7 +63,7 @@
 ///
 /// Objects -- classes and interfaces.
 ///
-/// ```
+/// ```ignore
 /// glib_wrapper! {
 ///     /// Object representing an input device.
 ///     pub struct Device(Object<ffi::GdkDevice>);
@@ -74,7 +74,7 @@
 /// }
 /// ```
 ///
-/// ```
+/// ```ignore
 /// glib_wrapper! {
 ///     /// A container with just one child.
 ///     pub struct Bin(Object<ffi::GtkBin>): Container, Widget, Buildable;


### PR DESCRIPTION
Here's the best compromise between type safety and ergonomics I've managed to achieve.
cc #73 

Examples:

```rust
    let mut value = glib::Value::from(Some("Hello world !"));
    println!("gvalue.get example: {}", value.typed::<String>().unwrap().get().unwrap());

    let mut int = glib::Value::from(1);
    int.typed_mut::<i32>().unwrap().set_some(&2);
    assert_eq!(int.get(), Some(2));

    for i in 0..10 {
        let iter = right_store.append(None);
        right_store.set_value(&iter, 0, &i.into());
    }
```