### PR TITLE
Switch to version features instead of autodetection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,16 @@ keywords = ["glib", "gtk", "gnome", "GUI"]
 name = "glib"
 
 [dependencies]
-gio-sys = { git = "https://github.com/gtk-rs/sys" }
-glib-sys = { git = "https://github.com/gtk-rs/sys" }
-gobject-sys = { git = "https://github.com/gtk-rs/sys" }
-libc = "0.1"
+libc = "0.2"
+
+[dependencies.gio-sys]
+git = "https://github.com/gtk-rs/sys"
+version = "0.3.0"
+
+[dependencies.glib-sys]
+git = "https://github.com/gtk-rs/sys"
+version = "0.3.0"
+
+[dependencies.gobject-sys]
+git = "https://github.com/gtk-rs/sys"
+version = "0.3.0"


### PR DESCRIPTION
Implement the reinstatement of version features outlined in https://github.com/gtk-rs/gtk/issues/243.

- Installed library version detection no longer impacts conditional compilation.
- Each crate defaults to supporting a particular minimal upstream version.
- Higher (newer) versions need to be enabled via cargo features e.g. `--features 3.16`, `features = ["3.16"]`.
- The selected version is checked against `pkg-config` aborting the build if it's too high.
- The use of `pkg-config` can be overridden by setting `GTK_LIB_DIR` env variable, which translates into `-L $GTK_LIB_DIR` linker argument. No version checks are done in this case.

[breaking change]