### PR TITLE
Add override_class_handler()

### DIFF
--- a/src/signal.rs
+++ b/src/signal.rs
@@ -4,9 +4,10 @@
 
 //! `IMPL` Low level signal support.
 
-use libc::c_void;
+use libc::{c_void, c_uint};
 
 use gobject_ffi::{self, GCallback};
+use glib_ffi::{GQuark, GType};
 use source::CallbackGuard;
 use translate::ToGlibPtr;
 
@@ -17,6 +18,10 @@ pub unsafe fn connect(receiver: *mut gobject_ffi::GObject, signal_name: &str, tr
         gobject_ffi::GConnectFlags::empty()) as u64;
     assert!(handle > 0);
     handle
+}
+
+pub unsafe fn stop_emission(instance: *mut gobject_ffi::GObject, signal_id: u32, detail: GQuark) {
+    gobject_ffi::g_signal_stop_emission(instance, signal_id as c_uint, detail);
 }
 
 unsafe extern "C" fn destroy_closure(ptr: *mut c_void, _: *mut gobject_ffi::GClosure) {


### PR DESCRIPTION
Looking to use this in the GTK library. This builds just fine and I believe that it's correct, but I can't compile the GTK project if I modify its `Cargo.toml` to put to my `glib` repo with this change. I get the following errors all related to a macro:
```
 Compiling gtk v0.0.8 (file:///home/susurrus/Projects/gtk)
<glib macros>:87:21: 87:60 error: the trait bound `gio::Application: glib::wrapper::Wrapper` is not satisfied [E0277]
<glib macros>:87 as * mut _ } } impl $ crate:: object:: IsA < $ super_name > for $ name {  } }
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<glib macros>:95:1: 95:79 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:101:1: 101:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:25:1: 27:36 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
src/auto/application.rs:17:1: 27:2 note: in this expansion of glib_wrapper! (defined in <glib macros>)
<glib macros>:87:21: 87:60 help: run `rustc --explain E0277` to see a detailed explanation
<glib macros>:87:21: 87:60 error: the trait bound `gio::Application: glib::wrapper::UnsafeFrom<glib::object::ObjectRef>` is not satisfied [E0277]
<glib macros>:87 as * mut _ } } impl $ crate:: object:: IsA < $ super_name > for $ name {  } }
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<glib macros>:95:1: 95:79 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:101:1: 101:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:25:1: 27:36 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
src/auto/application.rs:17:1: 27:2 note: in this expansion of glib_wrapper! (defined in <glib macros>)
<glib macros>:87:21: 87:60 help: run `rustc --explain E0277` to see a detailed explanation
<glib macros>:87:21: 87:60 note: required by `glib::IsA`
<glib macros>:87:21: 87:60 error: the trait bound `gio::Application: glib::StaticType` is not satisfied [E0277]
<glib macros>:87 as * mut _ } } impl $ crate:: object:: IsA < $ super_name > for $ name {  } }
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<glib macros>:95:1: 95:79 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:101:1: 101:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:25:1: 27:36 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
src/auto/application.rs:17:1: 27:2 note: in this expansion of glib_wrapper! (defined in <glib macros>)
<glib macros>:87:21: 87:60 help: run `rustc --explain E0277` to see a detailed explanation
<glib macros>:87:21: 87:60 note: required by `glib::IsA`
<glib macros>:87:21: 87:60 error: the trait bound `gio::ActionGroup: glib::wrapper::Wrapper` is not satisfied [E0277]
<glib macros>:87 as * mut _ } } impl $ crate:: object:: IsA < $ super_name > for $ name {  } }
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<glib macros>:95:1: 95:79 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:96:1: 96:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:101:1: 101:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:25:1: 27:36 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
src/auto/application.rs:17:1: 27:2 note: in this expansion of glib_wrapper! (defined in <glib macros>)
<glib macros>:87:21: 87:60 help: run `rustc --explain E0277` to see a detailed explanation
<glib macros>:87:21: 87:60 error: the trait bound `gio::ActionGroup: glib::wrapper::UnsafeFrom<glib::object::ObjectRef>` is not satisfied [E0277]
<glib macros>:87 as * mut _ } } impl $ crate:: object:: IsA < $ super_name > for $ name {  } }
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<glib macros>:95:1: 95:79 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:96:1: 96:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:101:1: 101:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:25:1: 27:36 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
src/auto/application.rs:17:1: 27:2 note: in this expansion of glib_wrapper! (defined in <glib macros>)
<glib macros>:87:21: 87:60 help: run `rustc --explain E0277` to see a detailed explanation
<glib macros>:87:21: 87:60 note: required by `glib::IsA`
<glib macros>:87:21: 87:60 error: the trait bound `gio::ActionGroup: glib::StaticType` is not satisfied [E0277]
<glib macros>:87 as * mut _ } } impl $ crate:: object:: IsA < $ super_name > for $ name {  } }
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<glib macros>:95:1: 95:79 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:96:1: 96:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:101:1: 101:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:25:1: 27:36 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
src/auto/application.rs:17:1: 27:2 note: in this expansion of glib_wrapper! (defined in <glib macros>)
<glib macros>:87:21: 87:60 help: run `rustc --explain E0277` to see a detailed explanation
<glib macros>:87:21: 87:60 note: required by `glib::IsA`
<glib macros>:87:21: 87:60 error: the trait bound `gio::ActionMap: glib::wrapper::Wrapper` is not satisfied [E0277]
<glib macros>:87 as * mut _ } } impl $ crate:: object:: IsA < $ super_name > for $ name {  } }
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<glib macros>:95:1: 95:79 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:96:1: 96:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:101:1: 101:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:25:1: 27:36 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
src/auto/application.rs:17:1: 27:2 note: in this expansion of glib_wrapper! (defined in <glib macros>)
<glib macros>:87:21: 87:60 help: run `rustc --explain E0277` to see a detailed explanation
<glib macros>:87:21: 87:60 error: the trait bound `gio::ActionMap: glib::wrapper::UnsafeFrom<glib::object::ObjectRef>` is not satisfied [E0277]
<glib macros>:87 as * mut _ } } impl $ crate:: object:: IsA < $ super_name > for $ name {  } }
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<glib macros>:95:1: 95:79 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:96:1: 96:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:101:1: 101:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:25:1: 27:36 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
src/auto/application.rs:17:1: 27:2 note: in this expansion of glib_wrapper! (defined in <glib macros>)
<glib macros>:87:21: 87:60 help: run `rustc --explain E0277` to see a detailed explanation
<glib macros>:87:21: 87:60 note: required by `glib::IsA`
<glib macros>:87:21: 87:60 error: the trait bound `gio::ActionMap: glib::StaticType` is not satisfied [E0277]
<glib macros>:87 as * mut _ } } impl $ crate:: object:: IsA < $ super_name > for $ name {  } }
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<glib macros>:95:1: 95:79 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:96:1: 96:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:101:1: 101:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:25:1: 27:36 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
src/auto/application.rs:17:1: 27:2 note: in this expansion of glib_wrapper! (defined in <glib macros>)
<glib macros>:87:21: 87:60 help: run `rustc --explain E0277` to see a detailed explanation
<glib macros>:87:21: 87:60 note: required by `glib::IsA`
src/auto/application.rs:140:5: 144:6 error: the trait bound `gio::MenuModel: glib::wrapper::Wrapper` is not satisfied [E0277]
src/auto/application.rs:140     pub fn set_app_menu<T: IsA<gio::MenuModel>>(&self, app_menu: Option<&T>) {
src/auto/application.rs:141         unsafe {
src/auto/application.rs:142             ffi::gtk_application_set_app_menu(self.to_glib_none().0, app_menu.to_glib_none().0);
src/auto/application.rs:143         }
src/auto/application.rs:144     }
src/auto/application.rs:140:5: 144:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/application.rs:140:5: 144:6 error: the trait bound `gio::MenuModel: glib::wrapper::Wrapper` is not satisfied [E0277]
src/auto/application.rs:140     pub fn set_app_menu<T: IsA<gio::MenuModel>>(&self, app_menu: Option<&T>) {
src/auto/application.rs:141         unsafe {
src/auto/application.rs:142             ffi::gtk_application_set_app_menu(self.to_glib_none().0, app_menu.to_glib_none().0);
src/auto/application.rs:143         }
src/auto/application.rs:144     }
src/auto/application.rs:140:5: 144:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/application.rs:140:5: 144:6 error: the trait bound `gio::MenuModel: glib::wrapper::UnsafeFrom<glib::object::ObjectRef>` is not satisfied [E0277]
src/auto/application.rs:140     pub fn set_app_menu<T: IsA<gio::MenuModel>>(&self, app_menu: Option<&T>) {
src/auto/application.rs:141         unsafe {
src/auto/application.rs:142             ffi::gtk_application_set_app_menu(self.to_glib_none().0, app_menu.to_glib_none().0);
src/auto/application.rs:143         }
src/auto/application.rs:144     }
src/auto/application.rs:140:5: 144:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/application.rs:140:5: 144:6 note: required by `glib::IsA`
src/auto/application.rs:140:5: 144:6 error: the trait bound `gio::MenuModel: glib::StaticType` is not satisfied [E0277]
src/auto/application.rs:140     pub fn set_app_menu<T: IsA<gio::MenuModel>>(&self, app_menu: Option<&T>) {
src/auto/application.rs:141         unsafe {
src/auto/application.rs:142             ffi::gtk_application_set_app_menu(self.to_glib_none().0, app_menu.to_glib_none().0);
src/auto/application.rs:143         }
src/auto/application.rs:144     }
src/auto/application.rs:140:5: 144:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/application.rs:140:5: 144:6 note: required by `glib::IsA`
src/auto/application.rs:146:5: 150:6 error: the trait bound `gio::MenuModel: glib::wrapper::Wrapper` is not satisfied [E0277]
src/auto/application.rs:146     pub fn set_menubar<T: IsA<gio::MenuModel>>(&self, menubar: Option<&T>) {
src/auto/application.rs:147         unsafe {
src/auto/application.rs:148             ffi::gtk_application_set_menubar(self.to_glib_none().0, menubar.to_glib_none().0);
src/auto/application.rs:149         }
src/auto/application.rs:150     }
src/auto/application.rs:146:5: 150:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/application.rs:146:5: 150:6 error: the trait bound `gio::MenuModel: glib::wrapper::Wrapper` is not satisfied [E0277]
src/auto/application.rs:146     pub fn set_menubar<T: IsA<gio::MenuModel>>(&self, menubar: Option<&T>) {
src/auto/application.rs:147         unsafe {
src/auto/application.rs:148             ffi::gtk_application_set_menubar(self.to_glib_none().0, menubar.to_glib_none().0);
src/auto/application.rs:149         }
src/auto/application.rs:150     }
src/auto/application.rs:146:5: 150:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/application.rs:146:5: 150:6 error: the trait bound `gio::MenuModel: glib::wrapper::UnsafeFrom<glib::object::ObjectRef>` is not satisfied [E0277]
src/auto/application.rs:146     pub fn set_menubar<T: IsA<gio::MenuModel>>(&self, menubar: Option<&T>) {
src/auto/application.rs:147         unsafe {
src/auto/application.rs:148             ffi::gtk_application_set_menubar(self.to_glib_none().0, menubar.to_glib_none().0);
src/auto/application.rs:149         }
src/auto/application.rs:150     }
src/auto/application.rs:146:5: 150:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/application.rs:146:5: 150:6 note: required by `glib::IsA`
src/auto/application.rs:146:5: 150:6 error: the trait bound `gio::MenuModel: glib::StaticType` is not satisfied [E0277]
src/auto/application.rs:146     pub fn set_menubar<T: IsA<gio::MenuModel>>(&self, menubar: Option<&T>) {
src/auto/application.rs:147         unsafe {
src/auto/application.rs:148             ffi::gtk_application_set_menubar(self.to_glib_none().0, menubar.to_glib_none().0);
src/auto/application.rs:149         }
src/auto/application.rs:150     }
src/auto/application.rs:146:5: 150:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/application.rs:146:5: 150:6 note: required by `glib::IsA`
<glib macros>:87:21: 87:60 error: the trait bound `gio::ActionGroup: glib::wrapper::Wrapper` is not satisfied [E0277]
<glib macros>:87 as * mut _ } } impl $ crate:: object:: IsA < $ super_name > for $ name {  } }
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<glib macros>:95:1: 95:79 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:92:1: 92:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:101:1: 101:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:25:1: 27:36 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
src/auto/application_window.rs:15:1: 28:2 note: in this expansion of glib_wrapper! (defined in <glib macros>)
<glib macros>:87:21: 87:60 help: run `rustc --explain E0277` to see a detailed explanation
<glib macros>:87:21: 87:60 error: the trait bound `gio::ActionGroup: glib::wrapper::UnsafeFrom<glib::object::ObjectRef>` is not satisfied [E0277]
<glib macros>:87 as * mut _ } } impl $ crate:: object:: IsA < $ super_name > for $ name {  } }
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<glib macros>:95:1: 95:79 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:92:1: 92:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:101:1: 101:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:25:1: 27:36 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
src/auto/application_window.rs:15:1: 28:2 note: in this expansion of glib_wrapper! (defined in <glib macros>)
<glib macros>:87:21: 87:60 help: run `rustc --explain E0277` to see a detailed explanation
<glib macros>:87:21: 87:60 note: required by `glib::IsA`
<glib macros>:87:21: 87:60 error: the trait bound `gio::ActionGroup: glib::StaticType` is not satisfied [E0277]
<glib macros>:87 as * mut _ } } impl $ crate:: object:: IsA < $ super_name > for $ name {  } }
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<glib macros>:95:1: 95:79 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:92:1: 92:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:101:1: 101:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:25:1: 27:36 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
src/auto/application_window.rs:15:1: 28:2 note: in this expansion of glib_wrapper! (defined in <glib macros>)
<glib macros>:87:21: 87:60 help: run `rustc --explain E0277` to see a detailed explanation
<glib macros>:87:21: 87:60 note: required by `glib::IsA`
<glib macros>:87:21: 87:60 error: the trait bound `gio::ActionMap: glib::wrapper::Wrapper` is not satisfied [E0277]
<glib macros>:87 as * mut _ } } impl $ crate:: object:: IsA < $ super_name > for $ name {  } }
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<glib macros>:95:1: 95:79 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:96:1: 96:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:92:1: 92:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:101:1: 101:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:25:1: 27:36 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
src/auto/application_window.rs:15:1: 28:2 note: in this expansion of glib_wrapper! (defined in <glib macros>)
<glib macros>:87:21: 87:60 help: run `rustc --explain E0277` to see a detailed explanation
<glib macros>:87:21: 87:60 error: the trait bound `gio::ActionMap: glib::wrapper::UnsafeFrom<glib::object::ObjectRef>` is not satisfied [E0277]
<glib macros>:87 as * mut _ } } impl $ crate:: object:: IsA < $ super_name > for $ name {  } }
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<glib macros>:95:1: 95:79 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:96:1: 96:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:92:1: 92:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:101:1: 101:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:25:1: 27:36 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
src/auto/application_window.rs:15:1: 28:2 note: in this expansion of glib_wrapper! (defined in <glib macros>)
<glib macros>:87:21: 87:60 help: run `rustc --explain E0277` to see a detailed explanation
<glib macros>:87:21: 87:60 note: required by `glib::IsA`
<glib macros>:87:21: 87:60 error: the trait bound `gio::ActionMap: glib::StaticType` is not satisfied [E0277]
<glib macros>:87 as * mut _ } } impl $ crate:: object:: IsA < $ super_name > for $ name {  } }
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<glib macros>:95:1: 95:79 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:96:1: 96:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:92:1: 92:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:101:1: 101:72 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
<glib macros>:25:1: 27:36 note: in this expansion of glib_object_wrapper! (defined in <glib macros>)
src/auto/application_window.rs:15:1: 28:2 note: in this expansion of glib_wrapper! (defined in <glib macros>)
<glib macros>:87:21: 87:60 help: run `rustc --explain E0277` to see a detailed explanation
<glib macros>:87:21: 87:60 note: required by `glib::IsA`
src/auto/image.rs:32:5: 37:6 error: the trait bound `gdk_pixbuf::PixbufAnimation: glib::wrapper::Wrapper` is not satisfied [E0277]
src/auto/image.rs:32     pub fn new_from_animation<T: IsA<gdk_pixbuf::PixbufAnimation>>(animation: &T) -> Image {
src/auto/image.rs:33         assert_initialized_main_thread!();
src/auto/image.rs:34         unsafe {
src/auto/image.rs:35             Widget::from_glib_none(ffi::gtk_image_new_from_animation(animation.to_glib_none().0)).downcast_unchecked()
src/auto/image.rs:36         }
src/auto/image.rs:37     }
src/auto/image.rs:32:5: 37:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/image.rs:32:5: 37:6 error: the trait bound `gdk_pixbuf::PixbufAnimation: glib::wrapper::Wrapper` is not satisfied [E0277]
src/auto/image.rs:32     pub fn new_from_animation<T: IsA<gdk_pixbuf::PixbufAnimation>>(animation: &T) -> Image {
src/auto/image.rs:33         assert_initialized_main_thread!();
src/auto/image.rs:34         unsafe {
src/auto/image.rs:35             Widget::from_glib_none(ffi::gtk_image_new_from_animation(animation.to_glib_none().0)).downcast_unchecked()
src/auto/image.rs:36         }
src/auto/image.rs:37     }
src/auto/image.rs:32:5: 37:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/image.rs:32:5: 37:6 error: the trait bound `gdk_pixbuf::PixbufAnimation: glib::wrapper::UnsafeFrom<glib::object::ObjectRef>` is not satisfied [E0277]
src/auto/image.rs:32     pub fn new_from_animation<T: IsA<gdk_pixbuf::PixbufAnimation>>(animation: &T) -> Image {
src/auto/image.rs:33         assert_initialized_main_thread!();
src/auto/image.rs:34         unsafe {
src/auto/image.rs:35             Widget::from_glib_none(ffi::gtk_image_new_from_animation(animation.to_glib_none().0)).downcast_unchecked()
src/auto/image.rs:36         }
src/auto/image.rs:37     }
src/auto/image.rs:32:5: 37:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/image.rs:32:5: 37:6 note: required by `glib::IsA`
src/auto/image.rs:32:5: 37:6 error: the trait bound `gdk_pixbuf::PixbufAnimation: glib::StaticType` is not satisfied [E0277]
src/auto/image.rs:32     pub fn new_from_animation<T: IsA<gdk_pixbuf::PixbufAnimation>>(animation: &T) -> Image {
src/auto/image.rs:33         assert_initialized_main_thread!();
src/auto/image.rs:34         unsafe {
src/auto/image.rs:35             Widget::from_glib_none(ffi::gtk_image_new_from_animation(animation.to_glib_none().0)).downcast_unchecked()
src/auto/image.rs:36         }
src/auto/image.rs:37     }
src/auto/image.rs:32:5: 37:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/image.rs:32:5: 37:6 note: required by `glib::IsA`
src/auto/image.rs:136:5: 140:6 error: the trait bound `gdk_pixbuf::PixbufAnimation: glib::wrapper::Wrapper` is not satisfied [E0277]
src/auto/image.rs:136     pub fn set_from_animation<T: IsA<gdk_pixbuf::PixbufAnimation>>(&self, animation: &T) {
src/auto/image.rs:137         unsafe {
src/auto/image.rs:138             ffi::gtk_image_set_from_animation(self.to_glib_none().0, animation.to_glib_none().0);
src/auto/image.rs:139         }
src/auto/image.rs:140     }
src/auto/image.rs:136:5: 140:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/image.rs:136:5: 140:6 error: the trait bound `gdk_pixbuf::PixbufAnimation: glib::wrapper::Wrapper` is not satisfied [E0277]
src/auto/image.rs:136     pub fn set_from_animation<T: IsA<gdk_pixbuf::PixbufAnimation>>(&self, animation: &T) {
src/auto/image.rs:137         unsafe {
src/auto/image.rs:138             ffi::gtk_image_set_from_animation(self.to_glib_none().0, animation.to_glib_none().0);
src/auto/image.rs:139         }
src/auto/image.rs:140     }
src/auto/image.rs:136:5: 140:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/image.rs:136:5: 140:6 error: the trait bound `gdk_pixbuf::PixbufAnimation: glib::wrapper::UnsafeFrom<glib::object::ObjectRef>` is not satisfied [E0277]
src/auto/image.rs:136     pub fn set_from_animation<T: IsA<gdk_pixbuf::PixbufAnimation>>(&self, animation: &T) {
src/auto/image.rs:137         unsafe {
src/auto/image.rs:138             ffi::gtk_image_set_from_animation(self.to_glib_none().0, animation.to_glib_none().0);
src/auto/image.rs:139         }
src/auto/image.rs:140     }
src/auto/image.rs:136:5: 140:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/image.rs:136:5: 140:6 note: required by `glib::IsA`
src/auto/image.rs:136:5: 140:6 error: the trait bound `gdk_pixbuf::PixbufAnimation: glib::StaticType` is not satisfied [E0277]
src/auto/image.rs:136     pub fn set_from_animation<T: IsA<gdk_pixbuf::PixbufAnimation>>(&self, animation: &T) {
src/auto/image.rs:137         unsafe {
src/auto/image.rs:138             ffi::gtk_image_set_from_animation(self.to_glib_none().0, animation.to_glib_none().0);
src/auto/image.rs:139         }
src/auto/image.rs:140     }
src/auto/image.rs:136:5: 140:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/image.rs:136:5: 140:6 note: required by `glib::IsA`
src/auto/menu.rs:36:5: 41:6 error: the trait bound `gio::MenuModel: glib::wrapper::Wrapper` is not satisfied [E0277]
src/auto/menu.rs:36     pub fn new_from_model<T: IsA<gio::MenuModel>>(model: &T) -> Menu {
src/auto/menu.rs:37         assert_initialized_main_thread!();
src/auto/menu.rs:38         unsafe {
src/auto/menu.rs:39             Widget::from_glib_none(ffi::gtk_menu_new_from_model(model.to_glib_none().0)).downcast_unchecked()
src/auto/menu.rs:40         }
src/auto/menu.rs:41     }
src/auto/menu.rs:36:5: 41:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/menu.rs:36:5: 41:6 error: the trait bound `gio::MenuModel: glib::wrapper::Wrapper` is not satisfied [E0277]
src/auto/menu.rs:36     pub fn new_from_model<T: IsA<gio::MenuModel>>(model: &T) -> Menu {
src/auto/menu.rs:37         assert_initialized_main_thread!();
src/auto/menu.rs:38         unsafe {
src/auto/menu.rs:39             Widget::from_glib_none(ffi::gtk_menu_new_from_model(model.to_glib_none().0)).downcast_unchecked()
src/auto/menu.rs:40         }
src/auto/menu.rs:41     }
src/auto/menu.rs:36:5: 41:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/menu.rs:36:5: 41:6 error: the trait bound `gio::MenuModel: glib::wrapper::UnsafeFrom<glib::object::ObjectRef>` is not satisfied [E0277]
src/auto/menu.rs:36     pub fn new_from_model<T: IsA<gio::MenuModel>>(model: &T) -> Menu {
src/auto/menu.rs:37         assert_initialized_main_thread!();
src/auto/menu.rs:38         unsafe {
src/auto/menu.rs:39             Widget::from_glib_none(ffi::gtk_menu_new_from_model(model.to_glib_none().0)).downcast_unchecked()
src/auto/menu.rs:40         }
src/auto/menu.rs:41     }
src/auto/menu.rs:36:5: 41:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/menu.rs:36:5: 41:6 note: required by `glib::IsA`
src/auto/menu.rs:36:5: 41:6 error: the trait bound `gio::MenuModel: glib::StaticType` is not satisfied [E0277]
src/auto/menu.rs:36     pub fn new_from_model<T: IsA<gio::MenuModel>>(model: &T) -> Menu {
src/auto/menu.rs:37         assert_initialized_main_thread!();
src/auto/menu.rs:38         unsafe {
src/auto/menu.rs:39             Widget::from_glib_none(ffi::gtk_menu_new_from_model(model.to_glib_none().0)).downcast_unchecked()
src/auto/menu.rs:40         }
src/auto/menu.rs:41     }
src/auto/menu.rs:36:5: 41:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/menu.rs:36:5: 41:6 note: required by `glib::IsA`
src/auto/menu_bar.rs:30:5: 35:6 error: the trait bound `gio::MenuModel: glib::wrapper::Wrapper` is not satisfied [E0277]
src/auto/menu_bar.rs:30     pub fn new_from_model<T: IsA<gio::MenuModel>>(model: &T) -> MenuBar {
src/auto/menu_bar.rs:31         assert_initialized_main_thread!();
src/auto/menu_bar.rs:32         unsafe {
src/auto/menu_bar.rs:33             Widget::from_glib_none(ffi::gtk_menu_bar_new_from_model(model.to_glib_none().0)).downcast_unchecked()
src/auto/menu_bar.rs:34         }
src/auto/menu_bar.rs:35     }
src/auto/menu_bar.rs:30:5: 35:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/menu_bar.rs:30:5: 35:6 error: the trait bound `gio::MenuModel: glib::wrapper::Wrapper` is not satisfied [E0277]
src/auto/menu_bar.rs:30     pub fn new_from_model<T: IsA<gio::MenuModel>>(model: &T) -> MenuBar {
src/auto/menu_bar.rs:31         assert_initialized_main_thread!();
src/auto/menu_bar.rs:32         unsafe {
src/auto/menu_bar.rs:33             Widget::from_glib_none(ffi::gtk_menu_bar_new_from_model(model.to_glib_none().0)).downcast_unchecked()
src/auto/menu_bar.rs:34         }
src/auto/menu_bar.rs:35     }
src/auto/menu_bar.rs:30:5: 35:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/menu_bar.rs:30:5: 35:6 error: the trait bound `gio::MenuModel: glib::wrapper::UnsafeFrom<glib::object::ObjectRef>` is not satisfied [E0277]
src/auto/menu_bar.rs:30     pub fn new_from_model<T: IsA<gio::MenuModel>>(model: &T) -> MenuBar {
src/auto/menu_bar.rs:31         assert_initialized_main_thread!();
src/auto/menu_bar.rs:32         unsafe {
src/auto/menu_bar.rs:33             Widget::from_glib_none(ffi::gtk_menu_bar_new_from_model(model.to_glib_none().0)).downcast_unchecked()
src/auto/menu_bar.rs:34         }
src/auto/menu_bar.rs:35     }
src/auto/menu_bar.rs:30:5: 35:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/menu_bar.rs:30:5: 35:6 note: required by `glib::IsA`
src/auto/menu_bar.rs:30:5: 35:6 error: the trait bound `gio::MenuModel: glib::StaticType` is not satisfied [E0277]
src/auto/menu_bar.rs:30     pub fn new_from_model<T: IsA<gio::MenuModel>>(model: &T) -> MenuBar {
src/auto/menu_bar.rs:31         assert_initialized_main_thread!();
src/auto/menu_bar.rs:32         unsafe {
src/auto/menu_bar.rs:33             Widget::from_glib_none(ffi::gtk_menu_bar_new_from_model(model.to_glib_none().0)).downcast_unchecked()
src/auto/menu_bar.rs:34         }
src/auto/menu_bar.rs:35     }
src/auto/menu_bar.rs:30:5: 35:6 help: run `rustc --explain E0277` to see a detailed explanation
src/auto/menu_bar.rs:30:5: 35:6 note: required by `glib::IsA`
error: aborting due to 39 previous errors
error: Could not compile `gtk`.

To learn more, run the command again with --verbose.
```