### PR TITLE
Add stop_emission()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,10 @@ pub use object::{
     Object,
     ObjectExt,
 };
+pub use signal::{
+    signal_stop_emission,
+    signal_stop_emission_by_name
+};
 pub use source::{
     CallbackGuard,
     Continue,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,4 @@
-//! Traits and essential types inteded for blanket imports.
+//! Traits and essential types intended for blanket imports.
 
 pub use {
     Cast,

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -8,6 +8,7 @@ use libc::{c_void, c_uint};
 
 use gobject_ffi::{self, GCallback};
 use glib_ffi::GQuark;
+use object::{IsA, Object};
 use source::CallbackGuard;
 use translate::ToGlibPtr;
 
@@ -23,6 +24,12 @@ pub unsafe fn connect(receiver: *mut gobject_ffi::GObject, signal_name: &str, tr
 pub fn signal_stop_emission<T: IsA<Object>>(instance: &T, signal_id: u32, detail: GQuark) {
     unsafe {
         gobject_ffi::g_signal_stop_emission(instance.to_glib_none().0, signal_id as c_uint, detail);
+    }
+}
+
+pub fn signal_stop_emission_by_name<T: IsA<Object>>(instance: &T, signal_name: &str) {
+    unsafe {
+        gobject_ffi::g_signal_stop_emission_by_name(instance.to_glib_none().0, signal_name.to_glib_none().0);
     }
 }
 

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -4,9 +4,10 @@
 
 //! `IMPL` Low level signal support.
 
-use libc::c_void;
+use libc::{c_void, c_uint};
 
 use gobject_ffi::{self, GCallback};
+use glib_ffi::GQuark;
 use source::CallbackGuard;
 use translate::ToGlibPtr;
 
@@ -17,6 +18,12 @@ pub unsafe fn connect(receiver: *mut gobject_ffi::GObject, signal_name: &str, tr
         gobject_ffi::GConnectFlags::empty()) as u64;
     assert!(handle > 0);
     handle
+}
+
+pub fn signal_stop_emission<T: IsA<Object>>(instance: &T, signal_id: u32, detail: GQuark) {
+    unsafe {
+        gobject_ffi::g_signal_stop_emission(instance.to_glib_none().0, signal_id as c_uint, detail);
+    }
 }
 
 unsafe extern "C" fn destroy_closure(ptr: *mut c_void, _: *mut gobject_ffi::GClosure) {


### PR DESCRIPTION
Adds the stop_emission() function. I believe the function signature and code is correct, but seems very straightforward to me, so may be wrong.

I haven't gotten this integrated into my code yet as I don't know how to get the `signal_id` or the `detail` argument yet, but I figured I'd post it now and report back once I've tried it out a bit.