### PR TITLE
Added glib::source_remove()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ pub use source::{
     idle_add,
     timeout_add,
     timeout_add_seconds,
+    source_remove,
 };
 pub use types::{
     StaticType,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,7 @@ pub use source::{
     timeout_add,
     timeout_add_seconds,
     source_remove,
+    Id as SourceId,
 };
 pub use types::{
     StaticType,

--- a/src/source.rs
+++ b/src/source.rs
@@ -111,3 +111,16 @@ where F: FnMut() -> Continue + Send + 'static {
             Some(trampoline), into_raw(func), Some(destroy_closure))
     }
 }
+
+/// Removes the source with the given id `tag` from the default main context.
+///
+/// It is a programmer error to attempt to remove a non-existent source.
+/// Note: source id are reused.
+///
+/// For historical reasons, the native function always returns true, so we
+/// ignore it here.
+pub fn source_remove(tag: u32) {
+    unsafe {
+        glib_ffi::g_source_remove(tag);
+    }
+}

--- a/src/source.rs
+++ b/src/source.rs
@@ -8,7 +8,26 @@ use std::process;
 use std::thread;
 use ffi as glib_ffi;
 use ffi::{gboolean, gpointer};
-use translate::ToGlib;
+use translate::{from_glib, FromGlib, ToGlib};
+
+/// The id of a source that is returned by `idle_add` and `timeout_add`.
+pub struct Id(u32);
+
+impl ToGlib for Id {
+    type GlibType = u32;
+
+    #[inline]
+    fn to_glib(&self) -> u32 {
+        self.0
+    }
+}
+
+impl FromGlib<u32> for Id {
+    #[inline]
+    fn from_glib(val: u32) -> Id {
+        Id(val)
+    }
+}
 
 /// Continue calling the closure in the future iterations or drop it.
 ///
@@ -69,12 +88,12 @@ fn into_raw<F: FnMut() -> Continue + Send + 'static>(func: F) -> gpointer {
 ///
 /// The default main loop almost always is the main loop of the main thread.
 /// Thus the closure is called on the main thread.
-pub fn idle_add<F>(func: F) -> u32
+pub fn idle_add<F>(func: F) -> Id
 where F: FnMut() -> Continue + Send + 'static {
-    unsafe {
+    from_glib(unsafe {
         glib_ffi::g_idle_add_full(glib_ffi::G_PRIORITY_DEFAULT_IDLE, Some(trampoline),
             into_raw(func), Some(destroy_closure))
-    }
+    })
 }
 
 /// Adds a closure to be called by the default main loop at regular intervals
@@ -87,12 +106,12 @@ where F: FnMut() -> Continue + Send + 'static {
 ///
 /// The default main loop almost always is the main loop of the main thread.
 /// Thus the closure is called on the main thread.
-pub fn timeout_add<F>(interval: u32, func: F) -> u32
+pub fn timeout_add<F>(interval: u32, func: F) -> Id
 where F: FnMut() -> Continue + Send + 'static {
-    unsafe {
+    from_glib(unsafe {
         glib_ffi::g_timeout_add_full(glib_ffi::G_PRIORITY_DEFAULT, interval, Some(trampoline),
             into_raw(func), Some(destroy_closure))
-    }
+    })
 }
 
 /// Adds a closure to be called by the default main loop at regular intervals
@@ -104,23 +123,23 @@ where F: FnMut() -> Continue + Send + 'static {
 ///
 /// The default main loop almost always is the main loop of the main thread.
 /// Thus the closure is called on the main thread.
-pub fn timeout_add_seconds<F>(interval: u32, func: F) -> u32
+pub fn timeout_add_seconds<F>(interval: u32, func: F) -> Id
 where F: FnMut() -> Continue + Send + 'static {
-    unsafe {
+    from_glib(unsafe {
         glib_ffi::g_timeout_add_seconds_full(glib_ffi::G_PRIORITY_DEFAULT, interval,
             Some(trampoline), into_raw(func), Some(destroy_closure))
-    }
+    })
 }
 
-/// Removes the source with the given id `tag` from the default main context.
+/// Removes the source with the given id `source_id` from the default main context.
 ///
 /// It is a programmer error to attempt to remove a non-existent source.
 /// Note: source id are reused.
 ///
 /// For historical reasons, the native function always returns true, so we
 /// ignore it here.
-pub fn source_remove(tag: u32) {
+pub fn source_remove(source_id: Id) {
     unsafe {
-        glib_ffi::g_source_remove(tag);
+        glib_ffi::g_source_remove(source_id.to_glib());
     }
 }


### PR DESCRIPTION
I could do `glib::idle_add()` but not remove it, so I wrapped `glib::source_remove()`.

Actually I wonder if that one couldn't be automated, in wish case this PR would totally be wrong.

Thanks.