### PR TITLE
Use g_object_ref_sink() instead of g_object_ref() everywhere

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -123,7 +123,7 @@ glib_wrapper! {
     pub struct ObjectRef(Shared<GObject>);
 
     match fn {
-        ref => |ptr| gobject_ffi::g_object_ref(ptr),
+        ref => |ptr| gobject_ffi::g_object_ref_sink(ptr),
         unref => |ptr| gobject_ffi::g_object_unref(ptr),
     }
 }


### PR DESCRIPTION
https://github.com/gtk-rs/gir/issues/367