### PR TITLE
Add Windows implementations for g_setenv, g_getenv, g_unsetenv and g_get_current_dir

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -101,7 +101,7 @@ pub fn get_user_name() -> Option<String> {
 #[cfg(not(windows))]
 pub fn get_current_dir() -> Option<String> {
     unsafe {
-        from_glib_none(ffi::g_get_current_dir())
+        from_glib_full(ffi::g_get_current_dir())
     }
 }
 
@@ -113,6 +113,6 @@ pub fn get_current_dir() -> Option<String> {
     }
 
     unsafe {
-        from_glib_none(g_get_current_dir_utf8())
+        from_glib_full(g_get_current_dir_utf8())
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -31,14 +31,26 @@ pub fn set_prgname(name: Option<&str>) {
     }
 }
 
-#[cfg(unix)]
+#[cfg(not(windows))]
 pub fn getenv(variable_name: &str) -> Option<String> {
     unsafe {
         from_glib_none(ffi::g_getenv(variable_name.to_glib_none().0))
     }
 }
 
-#[cfg(unix)]
+#[cfg(windows)]
+pub fn getenv(variable_name: &str) -> Option<String> {
+    use libc::c_char;
+    extern "C" {
+        fn g_getenv_utf8(variable: *const c_char) -> *const c_char;
+    }
+
+    unsafe {
+        from_glib_none(g_getenv_utf8(variable_name.to_glib_none().0))
+    }
+}
+
+#[cfg(not(windows))]
 pub fn setenv(variable_name: &str, value: &str, overwrite: bool) -> bool {
     unsafe {
         from_glib(ffi::g_setenv(variable_name.to_glib_none().0,
@@ -47,10 +59,36 @@ pub fn setenv(variable_name: &str, value: &str, overwrite: bool) -> bool {
     }
 }
 
-#[cfg(unix)]
+#[cfg(windows)]
+pub fn setenv(variable_name: &str, value: &str, overwrite: bool) -> bool {
+    use libc::c_char;
+    extern "C" {
+        fn g_setenv_utf8(variable: *const c_char, value: *const c_char, overwrite: ffi::gboolean) -> ffi::gboolean;
+    }
+
+    unsafe {
+        from_glib(g_setenv_utf8(variable_name.to_glib_none().0,
+                                value.to_glib_none().0,
+                                overwrite.to_glib()))
+    }
+}
+
+#[cfg(not(windows))]
 pub fn unsetenv(variable_name: &str) {
     unsafe {
         ffi::g_unsetenv(variable_name.to_glib_none().0)
+    }
+}
+
+#[cfg(windows)]
+pub fn unsetenv(variable_name: &str) {
+    use libc::c_char;
+    extern "C" {
+        fn g_unsetenv_utf8(variable: *const c_char);
+    }
+
+    unsafe {
+        g_unsetenv_utf8(variable_name.to_glib_none().0)
     }
 }
 
@@ -60,9 +98,21 @@ pub fn get_user_name() -> Option<String> {
     }
 }
 
-#[cfg(unix)]
+#[cfg(not(windows))]
 pub fn get_current_dir() -> Option<String> {
     unsafe {
         from_glib_none(ffi::g_get_current_dir())
+    }
+}
+
+#[cfg(windows)]
+pub fn get_current_dir() -> Option<String> {
+    use libc::c_char;
+    extern "C" {
+        fn g_get_current_dir_utf8() -> *mut c_char;
+    }
+
+    unsafe {
+        from_glib_none(g_get_current_dir_utf8())
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,6 +4,7 @@
 
 use ffi;
 use translate::*;
+use std::path::PathBuf;
 
 /// Same as [`get_prgname()`].
 ///
@@ -99,14 +100,14 @@ pub fn get_user_name() -> Option<String> {
 }
 
 #[cfg(not(windows))]
-pub fn get_current_dir() -> Option<String> {
+pub fn get_current_dir() -> Option<PathBuf> {
     unsafe {
         from_glib_full(ffi::g_get_current_dir())
     }
 }
 
 #[cfg(windows)]
-pub fn get_current_dir() -> Option<String> {
+pub fn get_current_dir() -> Option<PathBuf> {
     use libc::c_char;
     extern "C" {
         fn g_get_current_dir_utf8() -> *mut c_char;


### PR DESCRIPTION
There are equivalent functions with the _utf8() prefix on Windows, to which macros with the "normal" names are pointing.

See https://github.com/gtk-rs/glib/pull/169#issuecomment-302931512 and below