### PR TITLE
Implement StaticType and GValue traits for boxed/shared types too

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
 use ffi as glib_ffi;
+use gobject_ffi;
 use std::borrow::Borrow;
 use std::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
 use std::fmt;
@@ -35,6 +36,7 @@ glib_wrapper! {
     match fn {
         ref => |ptr| glib_ffi::g_bytes_ref(ptr),
         unref => |ptr| glib_ffi::g_bytes_unref(ptr),
+        get_type => || glib_ffi::g_bytes_get_type(),
     }
 }
 

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -12,7 +12,7 @@ use libc::{c_uint, c_void};
 
 use ffi as glib_ffi;
 use gobject_ffi;
-use translate::{ToGlibPtr, ToGlibPtrMut, Uninitialized, from_glib_none, Stash};
+use translate::{ToGlibPtr, ToGlibPtrMut, FromGlibPtrFull, Uninitialized, Stash, from_glib_none};
 use types::Type;
 use Value;
 use ToValue;
@@ -26,6 +26,7 @@ glib_wrapper! {
             gobject_ffi::g_closure_sink(ptr);
         },
         unref => |ptr| gobject_ffi::g_closure_unref(ptr),
+        get_type => || gobject_ffi::g_closure_get_type(),
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,7 @@ use std::ptr;
 use std::mem;
 use translate::*;
 use ffi as glib_ffi;
+use gobject_ffi;
 
 glib_wrapper! {
     /// A generic error capable of representing various error domains (types).
@@ -20,6 +21,7 @@ glib_wrapper! {
     match fn {
         copy => |ptr| glib_ffi::g_error_copy(ptr),
         free => |ptr| glib_ffi::g_error_free(ptr),
+        get_type => || glib_ffi::g_error_get_type(),
     }
 }
 

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -40,6 +40,7 @@
 
 use VariantTy;
 use ffi as glib_ffi;
+use gobject_ffi;
 use translate::*;
 use std::borrow::Cow;
 use std::cmp::{PartialEq, Eq};
@@ -59,6 +60,7 @@ glib_wrapper! {
     match fn {
         ref => |ptr| glib_ffi::g_variant_ref_sink(ptr),
         unref => |ptr| glib_ffi::g_variant_unref(ptr),
+        get_type => || glib_ffi::g_variant_type_get_gtype(),
     }
 }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -45,6 +45,8 @@
 ///
 /// `free`: `|*mut $foreign|` frees the value.
 ///
+/// `get_type`: `||` (optional) returns the `Type`, if any
+///
 /// ### Shared
 ///
 /// Records with reference counted shared ownership.
@@ -64,6 +66,8 @@
 /// `ref`: `|*mut $foreign|` increases the refcount.
 ///
 /// `unref`: `|*mut $foreign|` decreases the refcount.
+///
+/// `get_type`: `||` (optional) returns the `Type`, if any
 ///
 /// ### Object
 ///
@@ -126,6 +130,20 @@ macro_rules! glib_wrapper {
 
     (
         $(#[$attr:meta])*
+        pub struct $name:ident(Boxed<$ffi_name:path>);
+
+        match fn {
+            copy => |$copy_arg:ident| $copy_expr:expr,
+            free => |$free_arg:ident| $free_expr:expr,
+            get_type => || $get_type_expr:expr,
+        }
+    ) => {
+        glib_boxed_wrapper!([$($attr)*] $name, $ffi_name, @copy $copy_arg $copy_expr,
+            @free $free_arg $free_expr, @get_type $get_type_expr);
+    };
+
+    (
+        $(#[$attr:meta])*
         pub struct $name:ident(Shared<$ffi_name:path>);
 
         match fn {
@@ -135,6 +153,20 @@ macro_rules! glib_wrapper {
     ) => {
         glib_shared_wrapper!([$($attr)*] $name, $ffi_name, @ref $ref_arg $ref_expr,
             @unref $unref_arg $unref_expr);
+    };
+
+    (
+        $(#[$attr:meta])*
+        pub struct $name:ident(Shared<$ffi_name:path>);
+
+        match fn {
+            ref => |$ref_arg:ident| $ref_expr:expr,
+            unref => |$unref_arg:ident| $unref_expr:expr,
+            get_type => || $get_type_expr:expr,
+        }
+    ) => {
+        glib_shared_wrapper!([$($attr)*] $name, $ffi_name, @ref $ref_arg $ref_expr,
+            @unref $unref_arg $unref_expr, @get_type $get_type_expr);
     };
 
     (


### PR DESCRIPTION
As long as a get_type() function is provided to the macro.