### PR TITLE
Fix transfer full conversion of pointer arrays

### DIFF
--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -161,15 +161,14 @@ macro_rules! glib_boxed_wrapper {
 
         #[doc(hidden)]
         impl $crate::translate::FromGlibContainerAsVec<*mut $ffi_name, *mut *mut $ffi_name> for $name {
-            unsafe fn from_glib_none_num_as_vec(mut ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
+            unsafe fn from_glib_none_num_as_vec(ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
                 if num == 0 || ptr.is_null() {
                     return Vec::new();
                 }
 
                 let mut res = Vec::with_capacity(num);
-                for _ in 0..num {
-                    res.push($crate::translate::from_glib_none(ptr::read(ptr)));
-                    ptr = ptr.offset(1);
+                for i in 0..num {
+                    res.push($crate::translate::from_glib_none(ptr::read(ptr.offset(i as isize))));
                 }
                 res
             }
@@ -180,15 +179,14 @@ macro_rules! glib_boxed_wrapper {
                 res
             }
 
-            unsafe fn from_glib_full_num_as_vec(mut ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
+            unsafe fn from_glib_full_num_as_vec(ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
                 if num == 0 || ptr.is_null() {
                     return Vec::new();
                 }
 
                 let mut res = Vec::with_capacity(num);
-                for _ in 0..num {
-                    res.push($crate::translate::from_glib_full(ptr::read(ptr)));
-                    ptr = ptr.offset(1);
+                for i in 0..num {
+                    res.push($crate::translate::from_glib_full(ptr::read(ptr.offset(i as isize))));
                 }
                 glib_ffi::g_free(ptr as *mut _);
                 res

--- a/src/object.rs
+++ b/src/object.rs
@@ -294,15 +294,14 @@ macro_rules! glib_object_wrapper {
 
         #[doc(hidden)]
         impl $crate::translate::FromGlibContainerAsVec<*mut $ffi_name, *mut *mut $ffi_name> for $name {
-            unsafe fn from_glib_none_num_as_vec(mut ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
+            unsafe fn from_glib_none_num_as_vec(ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
                 if num == 0 || ptr.is_null() {
                     return Vec::new();
                 }
 
                 let mut res = Vec::with_capacity(num);
-                for _ in 0..num {
-                    res.push($crate::translate::from_glib_none(ptr::read(ptr)));
-                    ptr = ptr.offset(1);
+                for i in 0..num {
+                    res.push($crate::translate::from_glib_none(ptr::read(ptr.offset(i as isize))));
                 }
                 res
             }
@@ -313,15 +312,14 @@ macro_rules! glib_object_wrapper {
                 res
             }
 
-            unsafe fn from_glib_full_num_as_vec(mut ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
+            unsafe fn from_glib_full_num_as_vec(ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
                 if num == 0 || ptr.is_null() {
                     return Vec::new();
                 }
 
                 let mut res = Vec::with_capacity(num);
-                for _ in 0..num {
-                    res.push($crate::translate::from_glib_full(ptr::read(ptr)));
-                    ptr = ptr.offset(1);
+                for i in 0..num {
+                    res.push($crate::translate::from_glib_full(ptr::read(ptr.offset(i as isize))));
                 }
                 glib_ffi::g_free(ptr as *mut _);
                 res

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -141,15 +141,14 @@ macro_rules! glib_shared_wrapper {
 
         #[doc(hidden)]
         impl $crate::translate::FromGlibContainerAsVec<*mut $ffi_name, *mut *mut $ffi_name> for $name {
-            unsafe fn from_glib_none_num_as_vec(mut ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
+            unsafe fn from_glib_none_num_as_vec(ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
                 if num == 0 || ptr.is_null() {
                     return Vec::new();
                 }
 
                 let mut res = Vec::with_capacity(num);
-                for _ in 0..num {
-                    res.push($crate::translate::from_glib_none(ptr::read(ptr)));
-                    ptr = ptr.offset(1);
+                for i in 0..num {
+                    res.push($crate::translate::from_glib_none(ptr::read(ptr.offset(i as isize))));
                 }
                 res
             }
@@ -160,15 +159,14 @@ macro_rules! glib_shared_wrapper {
                 res
             }
 
-            unsafe fn from_glib_full_num_as_vec(mut ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
+            unsafe fn from_glib_full_num_as_vec(ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
                 if num == 0 || ptr.is_null() {
                     return Vec::new();
                 }
 
                 let mut res = Vec::with_capacity(num);
-                for _ in 0..num {
-                    res.push($crate::translate::from_glib_full(ptr::read(ptr)));
-                    ptr = ptr.offset(1);
+                for i in 0..num {
+                    res.push($crate::translate::from_glib_full(ptr::read(ptr.offset(i as isize))));
                 }
                 glib_ffi::g_free(ptr as *mut _);
                 res

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -981,15 +981,14 @@ where Self: Sized {
 macro_rules! impl_from_glib_container_as_vec_fundamental {
     ($name:ty) => {
         impl FromGlibContainerAsVec<$name, *const $name> for $name {
-            unsafe fn from_glib_none_num_as_vec(mut ptr: *const $name, num: usize) -> Vec<Self> {
+            unsafe fn from_glib_none_num_as_vec(ptr: *const $name, num: usize) -> Vec<Self> {
                 if num == 0 || ptr.is_null() {
                     return Vec::new();
                 }
 
                 let mut res = Vec::with_capacity(num);
-                for _ in 0..num {
-                    res.push(ptr::read(ptr));
-                    ptr = ptr.offset(1);
+                for i in 0..num {
+                    res.push(ptr::read(ptr.offset(i as isize)));
                 }
                 res
             }
@@ -1037,15 +1036,14 @@ impl_from_glib_container_as_vec_fundamental!(f64);
 macro_rules! impl_from_glib_container_as_vec_string {
     ($name:ty, $ffi_name:ty) => {
         impl FromGlibContainerAsVec<$ffi_name, *const $ffi_name> for $name {
-            unsafe fn from_glib_none_num_as_vec(mut ptr: *const $ffi_name, num: usize) -> Vec<Self> {
+            unsafe fn from_glib_none_num_as_vec(ptr: *const $ffi_name, num: usize) -> Vec<Self> {
                 if num == 0 || ptr.is_null() {
                     return Vec::new();
                 }
 
                 let mut res = Vec::with_capacity(num);
-                for _ in 0..num {
-                    res.push(from_glib_none(ptr::read(ptr) as $ffi_name));
-                    ptr = ptr.offset(1);
+                for i in 0..num {
+                    res.push(from_glib_none(ptr::read(ptr.offset(i as isize)) as $ffi_name));
                 }
                 res
             }
@@ -1072,15 +1070,14 @@ macro_rules! impl_from_glib_container_as_vec_string {
                 res
             }
 
-            unsafe fn from_glib_full_num_as_vec(mut ptr: *mut $ffi_name, num: usize) -> Vec<Self> {
+            unsafe fn from_glib_full_num_as_vec(ptr: *mut $ffi_name, num: usize) -> Vec<Self> {
                 if num == 0 || ptr.is_null() {
                     return Vec::new();
                 }
 
                 let mut res = Vec::with_capacity(num);
-                for _ in 0..num {
-                    res.push(from_glib_full(ptr::read(ptr)));
-                    ptr = ptr.offset(1);
+                for i in 0..num {
+                    res.push(from_glib_full(ptr::read(ptr.offset(i as isize))));
                 }
                 glib_ffi::g_free(ptr as *mut _);
                 res

--- a/src/value.rs
+++ b/src/value.rs
@@ -319,15 +319,14 @@ impl FromGlibPtrFull<*mut gobject_ffi::GValue> for Value {
 }
 
 impl FromGlibContainerAsVec<*mut gobject_ffi::GValue, *mut *mut gobject_ffi::GValue> for Value {
-    unsafe fn from_glib_none_num_as_vec(mut ptr: *mut *mut gobject_ffi::GValue, num: usize) -> Vec<Self> {
+    unsafe fn from_glib_none_num_as_vec(ptr: *mut *mut gobject_ffi::GValue, num: usize) -> Vec<Self> {
         if num == 0 || ptr.is_null() {
             return Vec::new();
         }
 
         let mut res = Vec::with_capacity(num);
-        for _ in 0..num {
-            res.push(from_glib_none(ptr::read(ptr)));
-            ptr = ptr.offset(1);
+        for i in 0..num {
+            res.push(from_glib_none(ptr::read(ptr.offset(i as isize))));
         }
         res
     }
@@ -338,15 +337,14 @@ impl FromGlibContainerAsVec<*mut gobject_ffi::GValue, *mut *mut gobject_ffi::GVa
         res
     }
 
-    unsafe fn from_glib_full_num_as_vec(mut ptr: *mut *mut gobject_ffi::GValue, num: usize) -> Vec<Self> {
+    unsafe fn from_glib_full_num_as_vec(ptr: *mut *mut gobject_ffi::GValue, num: usize) -> Vec<Self> {
         if num == 0 || ptr.is_null() {
             return Vec::new();
         }
 
         let mut res = Vec::with_capacity(num);
-        for _ in 0..num {
-            res.push(from_glib_full(ptr::read(ptr)));
-            ptr = ptr.offset(1);
+        for i in 0..num {
+            res.push(from_glib_full(ptr::read(ptr.offset(i as isize))));
         }
         glib_ffi::g_free(ptr as *mut _);
         res


### PR DESCRIPTION
Instead of the original pointer, the pointer at the end of the array was
being freed.