### PR TITLE
Make glib::Error Send/Sync

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,9 @@ glib_wrapper! {
     }
 }
 
+unsafe impl Send for Error {}
+unsafe impl Sync for Error {}
+
 impl Error {
     /// Creates an error with supplied error enum variant and message.
     pub fn new<T: ErrorDomain>(error: T, message: &str) -> Error {


### PR DESCRIPTION
This should be thread-safe since all fields are
"primitive" types, except for the message C string, which
is immutable.

Fixes #195