### PR TITLE
Add Cast::dynamic_cast()

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -770,7 +770,7 @@ impl<T: IsA<Object> + SetValue> ObjectExt for T {
 
 pub struct WeakRef<T: IsA<Object> + ?Sized>(Box<gobject_ffi::GWeakRef>, PhantomData<*const T>);
 
-impl<T: IsA<Object> + Cast + ?Sized> WeakRef<T> {
+impl<T: IsA<Object> + StaticType + UnsafeFrom<ObjectRef> + Wrapper + ?Sized> WeakRef<T> {
     pub fn upgrade(&self) -> Option<T> {
         unsafe {
             let ptr = gobject_ffi::g_weak_ref_get(mut_override(&*self.0));
@@ -778,7 +778,7 @@ impl<T: IsA<Object> + Cast + ?Sized> WeakRef<T> {
                 None
             } else {
                 let obj: Object = from_glib_full(ptr);
-                Some(Cast::downcast::<T>(obj).expect("Wrongly typed GWeakRef"))
+                Some(T::from(obj.into()))
             }
         }
     }


### PR DESCRIPTION
This does all type-checking at runtime and is required because it's not
always statically known at compile-time whether an object implements an
interface or not.

Also add notes about this limitation to Cast::downcast() and Cast::upcast().

And change Cast::is() to only perform runtime checking. It was always
doing runtime checking anyway, but in addition did compile-time checking
which is more restricted. If compile-time checking is wanted in
addition, Downcast::can_downcast() can be used for the old behaviour.

https://github.com/gtk-rs/glib/issues/205
