### PR TITLE
Fix crates version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ libc = "0.2"
 bitflags = "0.9"
 
 [dependencies.glib-sys]
-version = "0.5.0"
+version = "0.4.0"
 git = "https://github.com/gtk-rs/sys"
 
 [dependencies.gobject-sys]
-version = "0.5.0"
+version = "0.4.0"
 git = "https://github.com/gtk-rs/sys"
 
 [features]


### PR DESCRIPTION
This bug comes from my script which had glib defined twice in the crate list and so updated the crate's version twice as well... Just figured this out.