### PR TITLE
For the CallbackGuard, print something to stderr and use abort() inst…

### DIFF
--- a/src/source.rs
+++ b/src/source.rs
@@ -71,8 +71,12 @@ impl Default for CallbackGuard {
 
 impl Drop for CallbackGuard {
     fn drop(&mut self) {
+        use std::io::stderr;
+        use std::io::Write;
+
         if thread::panicking() {
-            process::exit(101);
+            let _ = stderr().write(b"Uncaught panic, exiting");
+            process::abort();
         }
     }
 }


### PR DESCRIPTION
…ead of exit()

Otherwise the process just silently exits without anybody knowing what's
wrong. With abort() we also make sure that no at_exit handlers are
called and it's easier to attach a debugger and/or get a coredump.

Fixes https://github.com/gtk-rs/glib/issues/224