### PR TITLE
Also require ToGlibPtr<_, *const _> for the IsA<_> trait

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -121,11 +121,13 @@ impl<T: IsA<Object>> Cast for T { }
 /// `T` always implements `IsA<T>`.
 pub trait IsA<T: StaticType + UnsafeFrom<ObjectRef> + Wrapper>: StaticType + Wrapper +
     Into<ObjectRef> + UnsafeFrom<ObjectRef> +
-    for<'a> ToGlibPtr<'a, *mut <T as Wrapper>::GlibType> { }
+    for<'a> ToGlibPtr<'a, *mut <T as Wrapper>::GlibType> +
+    for<'a> ToGlibPtr<'a, *const <T as Wrapper>::GlibType> { }
 
 impl<T> IsA<T> for T
 where T: StaticType + Wrapper + Into<ObjectRef> + UnsafeFrom<ObjectRef> +
-    for<'a> ToGlibPtr<'a, *mut <T as Wrapper>::GlibType> { }
+    for<'a> ToGlibPtr<'a, *mut <T as Wrapper>::GlibType> +
+    for<'a> ToGlibPtr<'a, *const <T as Wrapper>::GlibType> { }
 
 /// Downcasts support.
 pub trait Downcast<T> {


### PR DESCRIPTION
The macro is implementing both anyway, and we might need to be able to
generate const pointers for various FFI API.


@zeenix