### PR TITLE
Don't implement DerefMut on TypedValue

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -416,6 +416,7 @@ impl Drop for ValueArray {
 /// accepted.
 ///
 /// See the [module documentation](index.html) for more details.
+#[derive(Clone)]
 pub struct TypedValue<T>(Value, PhantomData<*const T>);
 
 impl<'a, T: FromValueOptional<'a> + SetValue> TypedValue<T> {
@@ -455,11 +456,6 @@ impl<'a, T: FromValueOptional<'a> + SetValue> TypedValue<T> {
     }
 }
 
-impl<T> Clone for TypedValue<T> {
-    fn clone(&self) -> Self {
-        TypedValue(self.0.clone(), PhantomData)
-    }
-}
 
 impl<T> fmt::Debug for TypedValue<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {

--- a/src/value.rs
+++ b/src/value.rs
@@ -185,7 +185,10 @@ impl fmt::Debug for Value {
         unsafe {
             let s: String = from_glib_full(
                 gobject_ffi::g_strdup_value_contents(self.to_glib_none().0));
-            write!(f, "Value({})", s)
+
+            f.debug_tuple("Value")
+                .field(&s)
+                .finish()
         }
     }
 }
@@ -456,10 +459,11 @@ impl<'a, T: FromValueOptional<'a> + SetValue> TypedValue<T> {
     }
 }
 
-
 impl<T> fmt::Debug for TypedValue<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "TypedValue({:?})", self.0)
+        f.debug_tuple("TypedValue")
+            .field(&self.0)
+            .finish()
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -420,6 +420,7 @@ impl Drop for ValueArray {
 ///
 /// See the [module documentation](index.html) for more details.
 #[derive(Clone)]
+#[repr(C)]
 pub struct TypedValue<T>(Value, PhantomData<*const T>);
 
 impl<'a, T: FromValueOptional<'a> + SetValue> TypedValue<T> {

--- a/src/value.rs
+++ b/src/value.rs
@@ -74,7 +74,7 @@ use std::borrow::Borrow;
 use std::fmt;
 use std::marker::PhantomData;
 use std::mem;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 use std::ffi::CStr;
 use std::ptr;
 use libc::c_void;
@@ -439,19 +439,19 @@ impl<'a, T: FromValueOptional<'a> + SetValue> TypedValue<T> {
     ///
     /// This method is only available for types that support a `None` value.
     pub fn set<U: ?Sized + SetValueOptional>(&mut self, value: Option<&U>) where T: Borrow<U> {
-        unsafe { SetValueOptional::set_value_optional(self, value) }
+        unsafe { SetValueOptional::set_value_optional(&mut self.0, value) }
     }
 
     /// Sets the value to `None`.
     ///
     /// This method is only available for types that support a `None` value.
     pub fn set_none(&mut self) where T: SetValueOptional {
-        unsafe { T::set_value_optional(self, None) }
+        unsafe { T::set_value_optional(&mut self.0, None) }
     }
 
     /// Sets the value.
     pub fn set_some<U: ?Sized + SetValue>(&mut self, value: &U) where T: Borrow<U> {
-        unsafe { SetValue::set_value(self, value) }
+        unsafe { SetValue::set_value(&mut self.0, value) }
     }
 }
 
@@ -472,12 +472,6 @@ impl<T> Deref for TypedValue<T> {
 
     fn deref(&self) -> &Value {
         &self.0
-    }
-}
-
-impl<T> DerefMut for TypedValue<T> {
-    fn deref_mut(&mut self) -> &mut Value {
-        &mut self.0
     }
 }
 


### PR DESCRIPTION
    It allows replacing the underlying Value inside the TypedValue with one
    of a different type and breaks type-safety:
    
      let mut meh: TypedValue<i32> = (&123i32).into();
      let meh2: Value = (&1u8).to_value();
      *meh = meh2;
    
    Fixes https://github.com/gtk-rs/glib/issues/254

Also includes some trivial cleanup.