### PR TITLE
Add Value::from_type() to initialize an empty value from a Type

### DIFF
--- a/src/enums.rs
+++ b/src/enums.rs
@@ -188,8 +188,7 @@ impl EnumValue {
     /// Convert enum value to a `Value`.
     pub fn to_value(&self) -> Value {
         unsafe {
-            let mut v = Value::uninitialized();
-            gobject_ffi::g_value_init(v.to_glib_none_mut().0, self.1.type_().to_glib());
+            let mut v = Value::from_type(self.1.type_());
             gobject_ffi::g_value_set_enum(v.to_glib_none_mut().0, (*self.0).value);
             v
         }
@@ -561,8 +560,7 @@ impl FlagsValue {
     /// Convert flags value to a `Value`.
     pub fn to_value(&self) -> Value {
         unsafe {
-            let mut v = Value::uninitialized();
-            gobject_ffi::g_value_init(v.to_glib_none_mut().0, self.1.type_().to_glib());
+            let mut v = Value::from_type(self.1.type_());
             gobject_ffi::g_value_set_flags(v.to_glib_none_mut().0, (*self.0).value);
             v
         }
@@ -619,12 +617,7 @@ impl Eq for FlagsValue {}
 pub struct FlagsBuilder<'a>(&'a FlagsClass, Option<Value>);
 impl<'a> FlagsBuilder<'a> {
     fn new(flags_class: &FlagsClass) -> FlagsBuilder {
-        let value = unsafe {
-            let mut value = Value::uninitialized();
-            gobject_ffi::g_value_init(value.to_glib_none_mut().0, flags_class.type_().to_glib());
-            value
-        };
-
+        let value = Value::from_type(flags_class.type_());
         FlagsBuilder(flags_class, Some(value))
     }
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -627,9 +627,7 @@ impl<T: IsA<Object> + SetValue> ObjectExt for T {
         };
 
         unsafe {
-            let mut value = Value::uninitialized();
-
-            gobject_ffi::g_value_init(value.to_glib_none_mut().0, property_type.to_glib());
+            let mut value = Value::from_type(property_type);
             gobject_ffi::g_object_get_property(self.to_glib_none().0, property_name.to_glib_none().0, value.to_glib_none_mut().0);
 
             // This can't really happen unless something goes wrong inside GObject

--- a/src/types.rs
+++ b/src/types.rs
@@ -187,10 +187,6 @@ impl StaticType for Vec<String> {
     }
 }
 
-pub trait InstanceType {
-    fn instance_type(&self) -> Type;
-}
-
 #[inline]
 pub unsafe fn instance_of<C: StaticType>(ptr: glib_ffi::gconstpointer) -> bool {
     from_glib(

--- a/src/value.rs
+++ b/src/value.rs
@@ -159,10 +159,11 @@ impl Value {
         }
     }
 
-    /// Returns `true` if the type of the value corresponds to `T`.
+    /// Returns `true` if the type of the value corresponds to `T`
+    /// or is a sub-type of `T`.
     #[inline]
     pub fn is<'a, T: FromValueOptional<'a> + SetValue>(&self) -> bool {
-        self.type_() == T::static_type()
+        self.type_().is_a(&T::static_type())
     }
 
     /// Returns the type of the value.


### PR DESCRIPTION
This is only allowed for types that can be stored in GValues and
otherwise panics. The returned value contains the empty/default value of
the corresponding type.


As suggested by @EPashkin here: https://github.com/gtk-rs/gir/pull/496#issuecomment-347242579
This could be used by GIR for all the property getters to initialize the value