### PR TITLE
Various Path FFI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
     packages:
     - libgtk-3-dev
 script:
+  - cargo test
   - rustc --version
   - mkdir .cargo
   - echo 'paths = ["."]' > .cargo/config

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ git = "https://github.com/gtk-rs/sys"
 version = "0.5.0"
 git = "https://github.com/gtk-rs/sys"
 
+[dev-dependencies]
+tempdir = "0.3"
+
 [features]
 v2_34 = ["glib-sys/v2_34", "gobject-sys/v2_34"]
 v2_38 = ["v2_34", "glib-sys/v2_38", "gobject-sys/v2_38"]

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -397,16 +397,32 @@ impl GlibPtrDefault for String {
 }
 
 #[cfg(unix)]
-fn path_to_c(path: &Path) -> Option<CString> {
+fn path_to_c(path: &Path) -> CString {
+    // GLib paths on UNIX are always in the local encoding, just like in Rust
+    //
+    // Paths on UNIX must not contain NUL bytes, in which case the conversion
+    // to a CString would fail. The only thing we can do then is to panic, as passing
+    // NULL or the empty string to GLib would cause undefined behaviour.
     use std::os::unix::ffi::OsStrExt;
-    CString::new(path.as_os_str().as_bytes()).ok()
+    CString::new(path.as_os_str().as_bytes())
+        .expect("Invalid path with NUL bytes")
 }
 
 #[cfg(not(unix))]
-fn path_to_c(path: &Path) -> Option<CString> {
-    path.to_str().and_then(|s| {
-        CString::new(s.as_bytes()).ok()
-    })
+fn path_to_c(path: &Path) -> CString {
+    // GLib paths are always UTF-8 strings on Windows, while in Rust they are
+    // WTF-8. As such, we need to convert to a UTF-8 string. This conversion can
+    // fail, see https://simonsapin.github.io/wtf-8/#converting-wtf-8-utf-8
+    //
+    // It's not clear what we're supposed to do if it fails: the path is not
+    // representable in UTF-8 and thus can't possibly be passed to GLib.
+    // Passing NULL or the empty string to GLib can lead to undefined behaviour, so
+    // the only safe option seems to be to simply panic here.
+    CString::new(path.to_str()
+        .expect("Path can't be represented as UTF-8")
+        .to_owned()
+        .into_bytes()
+    ).expect("Invalid path with NUL bytes")
 }
 
 impl<'a> ToGlibPtr<'a, *const c_char> for Path {
@@ -414,7 +430,7 @@ impl<'a> ToGlibPtr<'a, *const c_char> for Path {
 
     #[inline]
     fn to_glib_none(&'a self) -> Stash<'a, *const c_char, Self> {
-        let tmp = path_to_c(self).unwrap();
+        let tmp = path_to_c(self);
         Stash(tmp.as_ptr(), tmp)
     }
 }
@@ -424,7 +440,7 @@ impl<'a> ToGlibPtr<'a, *mut c_char> for Path {
 
     #[inline]
     fn to_glib_none(&'a self) -> Stash<'a, *mut c_char, Self> {
-        let tmp = path_to_c(self).unwrap();
+        let tmp = path_to_c(self);
         Stash(tmp.as_ptr() as *mut c_char, tmp)
     }
 }
@@ -434,7 +450,7 @@ impl<'a> ToGlibPtr<'a, *const c_char> for PathBuf {
 
     #[inline]
     fn to_glib_none(&'a self) -> Stash<'a, *const c_char, Self> {
-        let tmp = path_to_c(self).unwrap();
+        let tmp = path_to_c(self);
         Stash(tmp.as_ptr(), tmp)
     }
 }
@@ -444,7 +460,7 @@ impl<'a> ToGlibPtr<'a, *mut c_char> for PathBuf {
 
     #[inline]
     fn to_glib_none(&'a self) -> Stash<'a, *mut c_char, Self> {
-        let tmp = path_to_c(self).unwrap();
+        let tmp = path_to_c(self);
         Stash(tmp.as_ptr() as *mut c_char, tmp)
     }
 }
@@ -927,14 +943,25 @@ impl FromGlibPtrFull<*mut c_char> for String {
 
 #[cfg(unix)]
 unsafe fn c_to_path_buf(ptr: *const c_char) -> PathBuf {
+    assert!(!ptr.is_null());
+
+    // GLib paths on UNIX are always in the local encoding, which can be
+    // UTF-8 or anything else really, but is always a NUL-terminated string
+    // and must not contain any other NUL bytes
     OsString::from_vec(CStr::from_ptr(ptr).to_bytes().to_vec())
         .into()
 }
 
 #[cfg(not(unix))]
 unsafe fn c_to_path_buf(ptr: *const c_char) -> PathBuf {
-    String::from_utf8_lossy(CStr::from_ptr(ptr).to_bytes())
-        .into_owned()
+    assert!(!ptr.is_null());
+
+    // GLib paths on Windows are always UTF-8, as such we can convert to a String
+    // first and then go to a PathBuf from there. Unless there is a bug
+    // in the C library, the conversion from UTF-8 can never fail so we can
+    // safely panic here if that ever happens
+    String::from_utf8(CStr::from_ptr(ptr).to_bytes().into())
+        .expect("Invalid, non-UTF8 path")
         .into()
 }
 

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -51,10 +51,10 @@ use std::char;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::ffi::{CString, CStr};
-#[cfg(unix)]
+#[cfg(not(windows))]
 use std::ffi::OsString;
 use std::mem;
-#[cfg(unix)]
+#[cfg(not(windows))]
 use std::os::unix::prelude::*;
 use std::path::{Path, PathBuf};
 use std::ptr;
@@ -396,7 +396,7 @@ impl GlibPtrDefault for String {
     type GlibType = *mut c_char;
 }
 
-#[cfg(unix)]
+#[cfg(not(windows))]
 fn path_to_c(path: &Path) -> CString {
     // GLib paths on UNIX are always in the local encoding, just like in Rust
     //
@@ -408,7 +408,7 @@ fn path_to_c(path: &Path) -> CString {
         .expect("Invalid path with NUL bytes")
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
 fn path_to_c(path: &Path) -> CString {
     // GLib paths are always UTF-8 strings on Windows, while in Rust they are
     // WTF-8. As such, we need to convert to a UTF-8 string. This conversion can
@@ -950,7 +950,7 @@ impl FromGlibPtrFull<*mut c_char> for String {
     }
 }
 
-#[cfg(unix)]
+#[cfg(not(windows))]
 unsafe fn c_to_path_buf(ptr: *const c_char) -> PathBuf {
     assert!(!ptr.is_null());
 
@@ -961,7 +961,7 @@ unsafe fn c_to_path_buf(ptr: *const c_char) -> PathBuf {
         .into()
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
 unsafe fn c_to_path_buf(ptr: *const c_char) -> PathBuf {
     assert!(!ptr.is_null());
 


### PR DESCRIPTION
See commit messages for details.

The first is effectively not changing anything other than adding comments in the code, using expect() instead of unwrap() with more details, and not lossy converting non-UTF8 paths from GLib to Rust on Windows but fail instead on invalid UTF-8 (otherwise we might access the wrong file! potential data loss, etc, and it's a bug in the C library if that ever happens) 