### PR TITLE
Fix ToGlibContainerFromSlice impls for strings, boxed/object/shared s…

### DIFF
--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -124,7 +124,7 @@ macro_rules! glib_boxed_wrapper {
                 let v: Vec<_> = t.iter().map(|s| s.to_glib_none()).collect();
 
                 let v_ptr = unsafe {
-                    let v_ptr = glib_ffi::g_malloc0(mem::size_of::<*const $ffi_name>() * t.len() + 1) as *mut *const $ffi_name;
+                    let v_ptr = glib_ffi::g_malloc0(mem::size_of::<*const $ffi_name>() * (t.len() + 1)) as *mut *const $ffi_name;
 
                     for (i, s) in v.iter().enumerate() {
                         ptr::write(v_ptr.offset(i as isize), s.0);
@@ -138,7 +138,7 @@ macro_rules! glib_boxed_wrapper {
 
             fn to_glib_full_from_slice(t: &[$name]) -> *mut *const $ffi_name {
                 unsafe {
-                    let v_ptr = glib_ffi::g_malloc0(mem::size_of::<*const $ffi_name>() * t.len() + 1) as *mut *const $ffi_name;
+                    let v_ptr = glib_ffi::g_malloc0(mem::size_of::<*const $ffi_name>() * (t.len() + 1)) as *mut *const $ffi_name;
 
                     for (i, s) in t.iter().enumerate() {
                         ptr::write(v_ptr.offset(i as isize), s.to_glib_full());

--- a/src/object.rs
+++ b/src/object.rs
@@ -270,7 +270,7 @@ macro_rules! glib_object_wrapper {
                 let v: Vec<_> = t.iter().map(|s| s.to_glib_none()).collect();
 
                 let v_ptr = unsafe {
-                    let v_ptr = glib_ffi::g_malloc0(mem::size_of::<*mut $ffi_name>() * t.len() + 1) as *mut *mut $ffi_name;
+                    let v_ptr = glib_ffi::g_malloc0(mem::size_of::<*mut $ffi_name>() * (t.len() + 1)) as *mut *mut $ffi_name;
 
                     for (i, s) in v.iter().enumerate() {
                         ptr::write(v_ptr.offset(i as isize), s.0);
@@ -284,7 +284,7 @@ macro_rules! glib_object_wrapper {
 
             fn to_glib_full_from_slice(t: &[$name]) -> *mut *mut $ffi_name {
                 unsafe {
-                    let v_ptr = glib_ffi::g_malloc0(mem::size_of::<*mut $ffi_name>() * t.len() + 1) as *mut *mut $ffi_name;
+                    let v_ptr = glib_ffi::g_malloc0(mem::size_of::<*mut $ffi_name>() * (t.len() + 1)) as *mut *mut $ffi_name;
 
                     for (i, s) in t.iter().enumerate() {
                         ptr::write(v_ptr.offset(i as isize), s.to_glib_full());

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -104,7 +104,7 @@ macro_rules! glib_shared_wrapper {
                 let v: Vec<_> = t.iter().map(|s| s.to_glib_none()).collect();
 
                 let v_ptr = unsafe {
-                    let v_ptr = glib_ffi::g_malloc0(mem::size_of::<*mut $ffi_name>() * t.len() + 1) as *mut *mut $ffi_name;
+                    let v_ptr = glib_ffi::g_malloc0(mem::size_of::<*mut $ffi_name>() * (t.len() + 1)) as *mut *mut $ffi_name;
 
                     for (i, s) in v.iter().enumerate() {
                         ptr::write(v_ptr.offset(i as isize), s.0);
@@ -118,7 +118,7 @@ macro_rules! glib_shared_wrapper {
 
             fn to_glib_full_from_slice(t: &[$name]) -> *mut *mut $ffi_name {
                 unsafe {
-                    let v_ptr = glib_ffi::g_malloc0(mem::size_of::<*mut $ffi_name>() * t.len() + 1) as *mut *mut $ffi_name;
+                    let v_ptr = glib_ffi::g_malloc0(mem::size_of::<*mut $ffi_name>() * (t.len() + 1)) as *mut *mut $ffi_name;
 
                     for (i, s) in t.iter().enumerate() {
                         ptr::write(v_ptr.offset(i as isize), s.to_glib_full());

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -522,7 +522,7 @@ macro_rules! impl_to_glib_container_from_slice_string {
                 let v: Vec<_> = t.iter().map(|s| s.to_glib_none()).collect();
 
                 let v_ptr = unsafe {
-                    let v_ptr = glib_ffi::g_malloc0(mem::size_of::<$ffi_name>() * t.len() + 1) as *mut $ffi_name;
+                    let v_ptr = glib_ffi::g_malloc0(mem::size_of::<$ffi_name>() * (t.len() + 1)) as *mut $ffi_name;
 
                     for (i, s) in v.iter().enumerate() {
                         ptr::write(v_ptr.offset(i as isize), s.0);
@@ -536,7 +536,7 @@ macro_rules! impl_to_glib_container_from_slice_string {
 
             fn to_glib_full_from_slice(t: &[$name]) -> *mut $ffi_name {
                 unsafe {
-                    let v_ptr = glib_ffi::g_malloc0(mem::size_of::<$ffi_name>() * t.len() + 1) as *mut $ffi_name;
+                    let v_ptr = glib_ffi::g_malloc0(mem::size_of::<$ffi_name>() * (t.len() + 1)) as *mut $ffi_name;
 
                     for (i, s) in t.iter().enumerate() {
                         ptr::write(v_ptr.offset(i as isize), s.to_glib_full());


### PR DESCRIPTION
…tructs

It was missing parenthesis, so instead of a NULL pointer at the end
there was only a single NULL byte


This is likely the cause for the critical warnings on travis during the tests @EPashkin @GuillaumeGomez 