### PR TITLE
Add bindings for g_file_test() and make use of it in the Path transla…

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -18,6 +18,7 @@ generate = [
     "GLib.Time",
     "GLib.TimeType",
     "GLib.TimeSpan",
+    "GLib.FileTest",
 ]
 
 ignore = [

--- a/src/auto/flags.rs
+++ b/src/auto/flags.rs
@@ -5,6 +5,32 @@ use ffi;
 use translate::*;
 
 bitflags! {
+    pub struct FileTest: u32 {
+        const IS_REGULAR = 1;
+        const IS_SYMLINK = 2;
+        const IS_DIR = 4;
+        const IS_EXECUTABLE = 8;
+        const EXISTS = 16;
+    }
+}
+
+#[doc(hidden)]
+impl ToGlib for FileTest {
+    type GlibType = ffi::GFileTest;
+
+    fn to_glib(&self) -> ffi::GFileTest {
+        ffi::GFileTest::from_bits_truncate(self.bits())
+    }
+}
+
+#[doc(hidden)]
+impl FromGlib<ffi::GFileTest> for FileTest {
+    fn from_glib(value: ffi::GFileTest) -> FileTest {
+        FileTest::from_bits_truncate(value.bits())
+    }
+}
+
+bitflags! {
     pub struct FormatSizeFlags: u32 {
         const DEFAULT = 0;
         const LONG_FORMAT = 1;

--- a/src/auto/functions.rs
+++ b/src/auto/functions.rs
@@ -5,6 +5,7 @@
 use Bytes;
 use ChecksumType;
 use Error;
+use FileTest;
 use FormatSizeFlags;
 use Source;
 use UserDirectory;
@@ -408,9 +409,11 @@ pub fn file_set_contents<P: AsRef<std::path::Path>>(filename: P, contents: &[u8]
     }
 }
 
-//pub fn file_test<P: AsRef<std::path::Path>>(filename: P, test: /*Ignored*/FileTest) -> bool {
-//    unsafe { TODO: call ffi::g_file_test() }
-//}
+pub fn file_test<P: AsRef<std::path::Path>>(filename: P, test: FileTest) -> bool {
+    unsafe {
+        from_glib(ffi::g_file_test(filename.as_ref().to_glib_none().0, test.to_glib()))
+    }
+}
 
 pub fn filename_display_basename<P: AsRef<std::path::Path>>(filename: P) -> Option<String> {
     unsafe {

--- a/src/auto/mod.rs
+++ b/src/auto/mod.rs
@@ -30,6 +30,7 @@ pub use self::enums::KeyFileError;
 pub use self::enums::TimeType;
 
 mod flags;
+pub use self::flags::FileTest;
 pub use self::flags::FormatSizeFlags;
 pub use self::flags::KeyFileFlags;
 

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -1511,6 +1511,8 @@ mod tests {
         assert_eq!(::functions::path_get_basename(&dir_1), Some("abcd".into()));
         assert_eq!(::functions::path_get_basename(dir_1.canonicalize().unwrap()), Some("abcd".into()));
         assert_eq!(::functions::path_get_dirname(dir_1.canonicalize().unwrap()), Some(tmp_dir.path().into()));
+        assert!(::functions::file_test(&dir_1, ::FileTest::EXISTS | ::FileTest::IS_DIR));
+        assert!(::functions::file_test(&dir_1.canonicalize().unwrap(), ::FileTest::EXISTS | ::FileTest::IS_DIR));
 
         // And test with some non-ASCII characters
         let dir_2 = tmp_dir.as_ref().join("øäöü");
@@ -1518,5 +1520,7 @@ mod tests {
         assert_eq!(::functions::path_get_basename(&dir_2), Some("øäöü".into()));
         assert_eq!(::functions::path_get_basename(dir_2.canonicalize().unwrap()), Some("øäöü".into()));
         assert_eq!(::functions::path_get_dirname(dir_2.canonicalize().unwrap()), Some(tmp_dir.path().into()));
+        assert!(::functions::file_test(&dir_2, ::FileTest::EXISTS | ::FileTest::IS_DIR));
+        assert!(::functions::file_test(&dir_2.canonicalize().unwrap(), ::FileTest::EXISTS | ::FileTest::IS_DIR));
     }
 }


### PR DESCRIPTION
…tion tests

This ensures that we're not just doing the string transformations
correctly in one way or another, but actually refer to the same/correct
files.