### PR TITLE
Const override

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -15,6 +15,7 @@ generate = [
     "GLib.FormatSizeFlags",
     "GLib.KeyFileError",
     "GLib.KeyFileFlags",
+    "GLib.SeekType",
     "GLib.Time",
     "GLib.TimeType",
     "GLib.TimeSpan",

--- a/src/auto/enums.rs
+++ b/src/auto/enums.rs
@@ -235,6 +235,41 @@ impl ErrorDomain for KeyFileError {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum SeekType {
+    Cur,
+    Set,
+    End,
+    #[doc(hidden)]
+    __Unknown(i32),
+}
+
+#[doc(hidden)]
+impl ToGlib for SeekType {
+    type GlibType = ffi::GSeekType;
+
+    fn to_glib(&self) -> ffi::GSeekType {
+        match *self {
+            SeekType::Cur => ffi::G_SEEK_CUR,
+            SeekType::Set => ffi::G_SEEK_SET,
+            SeekType::End => ffi::G_SEEK_END,
+            SeekType::__Unknown(value) => value
+        }
+    }
+}
+
+#[doc(hidden)]
+impl FromGlib<ffi::GSeekType> for SeekType {
+    fn from_glib(value: ffi::GSeekType) -> Self {
+        match value {
+            0 => SeekType::Cur,
+            1 => SeekType::Set,
+            2 => SeekType::End,
+            value => SeekType::__Unknown(value),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum TimeType {
     Standard,
     Daylight,

--- a/src/auto/mod.rs
+++ b/src/auto/mod.rs
@@ -27,6 +27,7 @@ pub use self::enums::ChecksumType;
 pub use self::enums::DateMonth;
 pub use self::enums::DateWeekday;
 pub use self::enums::KeyFileError;
+pub use self::enums::SeekType;
 pub use self::enums::TimeType;
 
 mod flags;

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -97,6 +97,14 @@ pub fn mut_override<T>(ptr: *const T) -> *mut T {
     ptr as *mut T
 }
 
+/// Overrides pointer constness.
+///
+/// Use when the C API need const pointer, but function with `IsA<T>` constraint,
+/// that usaly don't have const pointer conversion.
+pub fn const_override<T>(ptr: *mut T) -> *const T {
+    ptr as *const T
+}
+
 /// A trait for creating an uninitialized value. Handy for receiving outparams.
 pub trait Uninitialized {
     /// Returns an uninitialized value.


### PR DESCRIPTION
Part of https://github.com/gtk-rs/glib/pull/249
Also include `GLib.SeekType` for future `gio.Seekable` generation.

cc @GuillaumeGomez , @sdroege 