### PR TITLE
Remove Default impl for SourceId

### DIFF
--- a/src/signal.rs
+++ b/src/signal.rs
@@ -28,6 +28,7 @@ impl ToGlib for SignalHandlerId {
 impl FromGlib<c_ulong> for SignalHandlerId {
     #[inline]
     fn from_glib(val: c_ulong) -> SignalHandlerId {
+        assert_ne!(val, 0);
         SignalHandlerId(val)
     }
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -29,6 +29,7 @@ impl ToGlib for SourceId {
 impl FromGlib<u32> for SourceId {
     #[inline]
     fn from_glib(val: u32) -> SourceId {
+        assert_ne!(val, 0);
         SourceId(val)
     }
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -14,9 +14,7 @@ use libc;
 use Source;
 
 /// The id of a source that is returned by `idle_add` and `timeout_add`.
-///
-/// A value of 0 is a good default as it is never a valid source ID.
-#[derive(Debug, Default, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct SourceId(u32);
 
 impl ToGlib for SourceId {


### PR DESCRIPTION
While 0 is never a valid SourceId, it is also not valid to use it with
any functions that work on SourceIds. It causes assertions at runtime.
The pattern of having a "non-existing" SourceId is better suited by
using an Option, and once NonZero is stabilized this can even be done
without introducing any memory overhead.