### PR TITLE
Improve set/get_property validity checks and allow to set properties from values that are a subtype of the property type

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -826,7 +826,10 @@ impl<T: IsA<Object> + SetValue> ObjectExt for T {
                 } else {
                     match ret {
                         Some(ret) => {
-                            if !ret.type_().is_a(&return_type) {
+                            let valid_type: bool = from_glib(gobject_ffi::g_type_check_value_holds(
+                                    mut_override(ret.to_glib_none().0),
+                                    return_type.to_glib()));
+                            if !valid_type {
                                 panic!("Signal required return value of type {} but got {}",
                                        return_type.name(), ret.type_().name());
                             }


### PR DESCRIPTION
See https://github.com/gtk-rs/glib/pull/308, extends that PR.

@tmiasko @GuillaumeGomez 