### PR TITLE
Add a Futures Executor around MainContext and various Future/Stream implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ name = "glib"
 lazy_static = "1.0"
 libc = "0.2"
 bitflags = "1.0"
-futures-core = { git = "https://github.com/rust-lang-nursery/futures-rs.git", optional = true }
-futures-executor = { git = "https://github.com/rust-lang-nursery/futures-rs.git", optional = true }
-futures-channel = { git = "https://github.com/rust-lang-nursery/futures-rs.git", optional = true }
-futures-util = { git = "https://github.com/rust-lang-nursery/futures-rs.git", optional = true }
+futures-core = { version = "0.2", optional = true }
+futures-executor = { version = "0.2", optional = true }
+futures-channel = { version = "0.2", optional = true }
+futures-util = { version = "0.2", optional = true }
 
 [dependencies.glib-sys]
 version = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ name = "glib"
 lazy_static = "1.0"
 libc = "0.2"
 bitflags = "1.0"
+futures-core = { git = "https://github.com/rust-lang-nursery/futures-rs.git", optional = true }
+futures-executor = { git = "https://github.com/rust-lang-nursery/futures-rs.git", optional = true }
+futures-channel = { git = "https://github.com/rust-lang-nursery/futures-rs.git", optional = true }
+futures-util = { git = "https://github.com/rust-lang-nursery/futures-rs.git", optional = true }
 
 [dependencies.glib-sys]
 version = "0.6.0"
@@ -43,4 +47,5 @@ v2_48 = ["v2_46", "glib-sys/v2_48"]
 v2_50 = ["v2_48", "glib-sys/v2_50"]
 v2_52 = ["v2_50", "glib-sys/v2_52"]
 v2_54 = ["v2_52", "glib-sys/v2_54", "gobject-sys/v2_54"]
+futures = ["futures-core", "futures-executor", "futures-channel", "futures-util", "v2_36"]
 dox = ["glib-sys/dox", "gobject-sys/dox"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,3 +190,7 @@ pub use date::Date;
 
 #[cfg(feature="futures")]
 mod main_context_futures;
+#[cfg(feature="futures")]
+mod source_futures;
+#[cfg(feature="futures")]
+pub use source_futures::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,15 @@ extern crate libc;
 extern crate glib_sys as ffi;
 extern crate gobject_sys as gobject_ffi;
 
+#[cfg(feature="futures")]
+extern crate futures_core;
+#[cfg(feature="futures")]
+extern crate futures_executor;
+#[cfg(feature="futures")]
+extern crate futures_channel;
+#[cfg(feature="futures")]
+extern crate futures_util;
+
 use std::ffi::CStr;
 pub use bytes::Bytes;
 pub use closure::Closure;
@@ -178,3 +187,6 @@ mod main_context;
 mod date_time;
 mod date;
 pub use date::Date;
+
+#[cfg(feature="futures")]
+mod main_context_futures;

--- a/src/main_context_futures.rs
+++ b/src/main_context_futures.rs
@@ -71,7 +71,7 @@ unsafe extern "C" fn prepare(
         // XXX: This is not actually correct, we should not dispatch the
         // GSource here already but we need to know its current status so
         // that if it is not ready yet something can register to the waker
-        if let Async::Ready(_) = source.poll() {
+        if let Async::Ready(()) = source.poll() {
             source.state.store(DONE, Ordering::SeqCst);
             cur = DONE;
         } else {
@@ -114,7 +114,7 @@ unsafe extern "C" fn dispatch(
         .state
         .compare_and_swap(READY, NOT_READY, Ordering::SeqCst);
     if cur == READY {
-        if let Async::Ready(_) = source.poll() {
+        if let Async::Ready(()) = source.poll() {
             source.state.store(DONE, Ordering::SeqCst);
             cur = DONE;
         } else {

--- a/src/main_context_futures.rs
+++ b/src/main_context_futures.rs
@@ -188,7 +188,8 @@ impl TaskSource {
                 *thread = Some(thread::current().id());
             }
             &mut Some(thread_id) => {
-                assert_eq!(thread::current().id(), thread_id);
+                assert_eq!(thread::current().id(), thread_id,
+                           "Task polled on a different thread than before");
             }
         }
 
@@ -262,7 +263,7 @@ impl MainContext {
     /// from any other `Future` that is executed on this main context, or after calling
     /// `push_thread_default` or `acquire` on the main context.
     pub fn spawn_local_with_priority<F: Future<Item = (), Error = Never> + 'static>(&mut self, priority: Priority, f: F) {
-        assert!(self.is_owner());
+        assert!(self.is_owner(), "Spawning local futures only allowed on the thread owning the MainContext");
         unsafe {
             // Ensure that this task is never polled on another thread
             // than this one where it was spawned now.

--- a/src/main_context_futures.rs
+++ b/src/main_context_futures.rs
@@ -17,6 +17,7 @@ use MainContext;
 use MainLoop;
 use Source;
 use Priority;
+use ::source::CallbackGuard;
 
 use ::translate::{from_glib_none, from_glib_full, mut_override, ToGlib};
 use ffi as glib_ffi;
@@ -57,6 +58,8 @@ unsafe extern "C" fn prepare(
     source: *mut glib_ffi::GSource,
     timeout: *mut i32,
 ) -> glib_ffi::gboolean {
+    let _guard = CallbackGuard::new();
+
     let source = &mut *(source as *mut TaskSource);
 
     *timeout = -1;
@@ -84,6 +87,8 @@ unsafe extern "C" fn prepare(
 }
 
 unsafe extern "C" fn check(source: *mut glib_ffi::GSource) -> glib_ffi::gboolean {
+    let _guard = CallbackGuard::new();
+
     let source = &mut *(source as *mut TaskSource);
 
     let cur = source.state.load(Ordering::SeqCst);
@@ -99,6 +104,8 @@ unsafe extern "C" fn dispatch(
     callback: glib_ffi::GSourceFunc,
     _user_data: glib_ffi::gpointer,
 ) -> glib_ffi::gboolean {
+    let _guard = CallbackGuard::new();
+
     let source = &mut *(source as *mut TaskSource);
     assert!(callback.is_none());
 
@@ -123,6 +130,8 @@ unsafe extern "C" fn dispatch(
 }
 
 unsafe extern "C" fn finalize(source: *mut glib_ffi::GSource) {
+    let _guard = CallbackGuard::new();
+
     let source = source as *mut TaskSource;
     let _ = (*source).future.take();
 }

--- a/src/main_context_futures.rs
+++ b/src/main_context_futures.rs
@@ -1,0 +1,280 @@
+// Copyright 2018, The Gtk-rs Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+use std::mem;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+
+use futures_core;
+use futures_core::executor::{Executor, SpawnError};
+use futures_core::task::{LocalMap, UnsafeWake, Waker};
+use futures_core::{Async, Future, Never};
+use futures_executor;
+use futures_util::future::FutureExt;
+
+use MainContext;
+use MainLoop;
+use Source;
+use Priority;
+
+use ::translate::{from_glib_none, from_glib_full, mut_override, ToGlib};
+use ffi as glib_ffi;
+
+// We can't use an enum here because we want to store this in an atomic variable
+const INIT: usize = 0;
+const NOT_READY: usize = 1;
+const READY: usize = 2;
+const DONE: usize = 3;
+
+#[repr(C)]
+struct TaskSource {
+    source: glib_ffi::GSource,
+    future: Option<(Box<Future<Item = (), Error = Never>>, Box<LocalMap>)>,
+    thread: Option<thread::ThreadId>,
+    state: AtomicUsize,
+}
+
+unsafe impl UnsafeWake for TaskSource {
+    unsafe fn clone_raw(&self) -> Waker {
+        Waker::new(glib_ffi::g_source_ref(mut_override(&self.source)) as *const TaskSource)
+    }
+
+    unsafe fn drop_raw(&self) {
+        glib_ffi::g_source_unref(mut_override(&self.source));
+    }
+
+    unsafe fn wake(&self) {
+        if self.state
+            .compare_and_swap(NOT_READY, READY, Ordering::SeqCst) == READY
+        {
+            glib_ffi::g_source_set_ready_time(mut_override(&self.source), 0);
+        }
+    }
+}
+
+unsafe extern "C" fn prepare(
+    source: *mut glib_ffi::GSource,
+    timeout: *mut i32,
+) -> glib_ffi::gboolean {
+    let source = &mut *(source as *mut TaskSource);
+
+    *timeout = -1;
+
+    let mut cur = source
+        .state
+        .compare_and_swap(INIT, NOT_READY, Ordering::SeqCst);
+    if cur == INIT {
+        // XXX: This is not actually correct, we should not dispatch the
+        // GSource here already but we need to know its current status so
+        // that if it is not ready yet something can register to the waker
+        if let Async::Ready(_) = source.poll() {
+            source.state.store(DONE, Ordering::SeqCst);
+            cur = DONE;
+        } else {
+            cur = NOT_READY;
+        }
+    }
+
+    if cur == READY || cur == DONE {
+        glib_ffi::GTRUE
+    } else {
+        glib_ffi::GFALSE
+    }
+}
+
+unsafe extern "C" fn check(source: *mut glib_ffi::GSource) -> glib_ffi::gboolean {
+    let source = &mut *(source as *mut TaskSource);
+
+    let cur = source.state.load(Ordering::SeqCst);
+    if cur == READY || cur == DONE {
+        glib_ffi::GTRUE
+    } else {
+        glib_ffi::GFALSE
+    }
+}
+
+unsafe extern "C" fn dispatch(
+    source: *mut glib_ffi::GSource,
+    callback: glib_ffi::GSourceFunc,
+    _user_data: glib_ffi::gpointer,
+) -> glib_ffi::gboolean {
+    let source = &mut *(source as *mut TaskSource);
+    assert!(callback.is_none());
+
+    glib_ffi::g_source_set_ready_time(mut_override(&source.source), -1);
+    let mut cur = source
+        .state
+        .compare_and_swap(READY, NOT_READY, Ordering::SeqCst);
+    if cur == READY {
+        if let Async::Ready(_) = source.poll() {
+            source.state.store(DONE, Ordering::SeqCst);
+            cur = DONE;
+        } else {
+            cur = NOT_READY;
+        }
+    }
+
+    if cur == DONE {
+        glib_ffi::G_SOURCE_REMOVE
+    } else {
+        glib_ffi::G_SOURCE_CONTINUE
+    }
+}
+
+unsafe extern "C" fn finalize(source: *mut glib_ffi::GSource) {
+    let source = source as *mut TaskSource;
+    let _ = (*source).future.take();
+}
+
+static SOURCE_FUNCS: glib_ffi::GSourceFuncs = glib_ffi::GSourceFuncs {
+    check: Some(check),
+    prepare: Some(prepare),
+    dispatch: Some(dispatch),
+    finalize: Some(finalize),
+    closure_callback: None,
+    closure_marshal: None,
+};
+
+impl TaskSource {
+    fn new(
+        priority: Priority,
+        future: Box<Future<Item = (), Error = Never> + 'static + Send>,
+    ) -> Source {
+        unsafe { Self::new_unsafe(priority, None, future) }
+    }
+
+    // NOTE: This does not have the Send bound and requires to be called from the same
+    // thread where the main context is running
+    unsafe fn new_unsafe(
+        priority: Priority,
+        thread: Option<thread::ThreadId>,
+        future: Box<Future<Item = (), Error = Never> + 'static>,
+    ) -> Source {
+        let source = glib_ffi::g_source_new(
+            mut_override(&SOURCE_FUNCS),
+            mem::size_of::<TaskSource>() as u32,
+        );
+        {
+            let source = &mut *(source as *mut TaskSource);
+            source.future = Some((future, Box::new(LocalMap::new())));
+            source.thread = thread;
+            source.state = AtomicUsize::new(INIT);
+        }
+
+        glib_ffi::g_source_set_priority(source, priority.to_glib());
+
+        from_glib_full(source)
+    }
+
+    fn poll(&mut self) -> Async<()> {
+        // Make sure that the first time we're polled that the current thread is remembered
+        // and from there one we ensure that we're always polled from exactly the same thread.
+        //
+        // In theory a GMainContext can be first run from one thread and later from another
+        // thread, but we allow spawning non-Send futures and must not ever use them from
+        // any other thread.
+        match &mut self.thread {
+            thread @ &mut None => {
+                *thread = Some(thread::current().id());
+            }
+            &mut Some(thread_id) => {
+                assert_eq!(thread::current().id(), thread_id);
+            }
+        }
+
+        let waker = unsafe { self.clone_raw() };
+        let source = &self.source as *const _;
+        if let Some(ref mut future) = self.future {
+            let (ref mut future, ref mut local_map) = *future;
+
+            let mut executor: MainContext = unsafe {
+                from_glib_none(glib_ffi::g_source_get_context(mut_override(source)))
+            };
+
+            // Clone that we store in the task local data so that
+            // it can be retrieved as needed
+            executor.push_thread_default();
+
+            let res = {
+                let enter = futures_executor::enter().unwrap();
+                let mut context =
+                    futures_core::task::Context::new(local_map, &waker, &mut executor);
+
+                let res = future.poll(&mut context).unwrap_or(Async::Ready(()));
+
+                drop(enter);
+
+                res
+            };
+
+            executor.pop_thread_default();
+            res
+        } else {
+            Async::Ready(())
+        }
+    }
+}
+
+impl MainContext {
+    pub fn spawn<F: Future<Item = (), Error = Never> + Send + 'static>(&mut self, f: F) {
+        self.spawn_with_priority(::PRIORITY_DEFAULT, f);
+    }
+
+    pub fn spawn_local<F: Future<Item = (), Error = Never> + 'static>(&mut self, f: F) {
+        self.spawn_local_with_priority(::PRIORITY_DEFAULT, f);
+    }
+
+    pub fn spawn_with_priority<F: Future<Item = (), Error = Never> + Send + 'static>(&mut self, priority: Priority, f: F) {
+        let source = TaskSource::new(priority, Box::new(f));
+        source.attach(Some(&*self));
+    }
+
+    pub fn spawn_local_with_priority<F: Future<Item = (), Error = Never> + 'static>(&mut self, priority: Priority, f: F) {
+        assert!(self.is_owner());
+        unsafe {
+            // Ensure that this task is never polled on another thread
+            // than this one where it was spawned now.
+            let source = TaskSource::new_unsafe(priority, Some(thread::current().id()), Box::new(f));
+            source.attach(Some(&*self));
+        }
+    }
+
+    pub fn block_on<F: Future>(&mut self, f: F) -> Result<F::Item, F::Error> {
+        let mut res = None;
+        let l = MainLoop::new(Some(&*self), false);
+        let l_clone = l.clone();
+
+        let source = unsafe {
+            let future = f.then(|r| {
+                res = Some(r);
+                l_clone.quit();
+                Ok::<(), Never>(())
+            });
+
+            let future: *mut Future<Item = (), Error = Never> = Box::into_raw(Box::new(future));
+            // XXX: Transmute to get a 'static lifetime here, super unsafe
+            let future: *mut (Future<Item = (), Error = Never> + 'static) = mem::transmute(future);
+            let future: Box<Future<Item = (), Error = Never> + 'static> = Box::from_raw(future);
+
+            // Ensure that this task is never polled on another thread
+            // than this one where it was spawned now.
+            TaskSource::new_unsafe(::PRIORITY_DEFAULT, Some(thread::current().id()), future)
+        };
+
+        source.attach(Some(&*self));
+
+        l.run();
+
+        res.unwrap()
+    }
+}
+
+impl Executor for MainContext {
+    fn spawn(&mut self, f: Box<Future<Item = (), Error = Never> + Send>) -> Result<(), SpawnError> {
+        let source = TaskSource::new(::PRIORITY_DEFAULT, f);
+        source.attach(Some(&*self));
+        Ok(())
+    }
+}
+

--- a/src/source.rs
+++ b/src/source.rs
@@ -39,8 +39,11 @@ impl FromGlib<u32> for SourceId {
 }
 
 /// Process identificator
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Pid(pub glib_ffi::GPid);
+
+unsafe impl Send for Pid {}
+unsafe impl Sync for Pid {}
 
 /// Continue calling the closure in the future iterations or drop it.
 ///

--- a/src/source_futures.rs
+++ b/src/source_futures.rs
@@ -1,0 +1,265 @@
+// Copyright 2018, The Gtk-rs Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+use futures_channel::{mpsc, oneshot};
+use futures_core::stream::Stream;
+use futures_core::task::Context;
+use futures_core::{Async, Future, Never};
+
+use MainContext;
+use Source;
+use Continue;
+use Priority;
+
+pub struct SourceFuture<F, T> {
+    create_source: Option<F>,
+    source: Option<(Source, oneshot::Receiver<T>)>,
+}
+
+impl<F, T: 'static> SourceFuture<F, T>
+where
+    F: FnOnce(oneshot::Sender<T>) -> Source + Send + 'static,
+{
+    pub fn new(create_source: F) -> Box<Future<Item = T, Error = Never>> {
+        Box::new(SourceFuture {
+            create_source: Some(create_source),
+            source: None,
+        })
+    }
+}
+
+impl<F, T> Future for SourceFuture<F, T>
+where
+    F: FnOnce(oneshot::Sender<T>) -> Source + Send + 'static,
+{
+    type Item = T;
+    type Error = Never;
+
+    fn poll(&mut self, ctx: &mut Context) -> Result<Async<T>, Never> {
+        let SourceFuture {
+            ref mut create_source,
+            ref mut source,
+            ..
+        } = *self;
+
+        if let Some(create_source) = create_source.take() {
+            let main_context = MainContext::ref_thread_default();
+            match main_context {
+                None => unreachable!(),
+                Some(ref main_context) => {
+                    assert!(main_context.is_owner());
+
+                    // Channel for sending back the Source result to our future here.
+                    //
+                    // In theory we could directly continue polling the
+                    // corresponding task from the Source callback,
+                    // however this would break at the very least
+                    // the g_main_current_source() API.
+                    let (send, recv) = oneshot::channel();
+
+                    let s = create_source(send);
+
+                    s.attach(Some(main_context));
+                    *source = Some((s, recv));
+                }
+            }
+        }
+
+        // At this point we must have a receiver
+        let res = {
+            let &mut (_, ref mut receiver) = source.as_mut().unwrap();
+            receiver.poll(ctx)
+        };
+        match res {
+            Err(_) => unreachable!(),
+            Ok(Async::Ready(v)) => {
+                // Get rid of the reference to the source, it triggered
+                let _ = source.take();
+                Ok(Async::Ready(v))
+            }
+            Ok(Async::Pending) => Ok(Async::Pending),
+        }
+    }
+}
+
+impl<T, F> Drop for SourceFuture<T, F> {
+    fn drop(&mut self) {
+        // Get rid of the source, we don't care anymore if it still triggers
+        if let Some((source, _)) = self.source.take() {
+            source.destroy();
+        }
+    }
+}
+
+pub fn timeout_future(value: u32) -> Box<Future<Item = (), Error = Never>> {
+    timeout_future_with_priority(::PRIORITY_DEFAULT, value)
+}
+
+pub fn timeout_future_with_priority(priority: Priority, value: u32) -> Box<Future<Item = (), Error = Never>> {
+    SourceFuture::new(move |send| {
+        let mut send = Some(send);
+        ::timeout_source_new(value, None, priority, move || {
+            let _ = send.take().unwrap().send(());
+            Continue(false)
+        })
+    })
+}
+
+pub fn timeout_future_seconds(value: u32) -> Box<Future<Item = (), Error = Never>> {
+    timeout_future_seconds_with_priority(::PRIORITY_DEFAULT, value)
+}
+
+pub fn timeout_future_seconds_with_priority(priority: Priority, value: u32) -> Box<Future<Item = (), Error = Never>> {
+    SourceFuture::new(move |send| {
+        let mut send = Some(send);
+        ::timeout_source_new_seconds(value, None, priority, move || {
+            let _ = send.take().unwrap().send(());
+            Continue(false)
+        })
+    })
+}
+
+pub fn child_watch_future(pid: ::Pid) -> Box<Future<Item = (::Pid, i32), Error = Never>> {
+    child_watch_future_with_priority(::PRIORITY_DEFAULT, pid)
+}
+
+pub fn child_watch_future_with_priority(priority: Priority, pid: ::Pid) -> Box<Future<Item = (::Pid, i32), Error = Never>> {
+    SourceFuture::new(move |send| {
+        let mut send = Some(send);
+        ::child_watch_source_new(pid, None, priority, move |pid, code| {
+            let _ = send.take().unwrap().send((pid, code));
+        })
+    })
+}
+
+#[cfg(any(unix, feature = "dox"))]
+pub fn unix_signal_future(signum: i32) -> Box<Future<Item = (), Error = Never>> {
+    unix_signal_future_with_priority(::PRIORITY_DEFAULT, signum)
+}
+
+#[cfg(any(unix, feature = "dox"))]
+pub fn unix_signal_future_with_priority(priority: Priority, signum: i32) -> Box<Future<Item = (), Error = Never>> {
+    SourceFuture::new(move |send| {
+        let mut send = Some(send);
+        ::unix_signal_source_new(signum, None, priority, move || {
+            let _ = send.take().unwrap().send(());
+            Continue(false)
+        })
+    })
+}
+
+pub struct SourceStream<F, T> {
+    create_source: Option<F>,
+    source: Option<(Source, mpsc::UnboundedReceiver<T>)>,
+}
+
+impl<F, T: 'static> SourceStream<F, T>
+where
+    F: FnOnce(mpsc::UnboundedSender<T>) -> Source + Send + 'static,
+{
+    pub fn new(create_source: F) -> Box<Stream<Item = T, Error = Never>> {
+        Box::new(SourceStream {
+            create_source: Some(create_source),
+            source: None,
+        })
+    }
+}
+
+impl<F, T> Stream for SourceStream<F, T>
+where
+    F: FnOnce(mpsc::UnboundedSender<T>) -> Source + Send + 'static,
+{
+    type Item = T;
+    type Error = Never;
+
+    fn poll_next(&mut self, ctx: &mut Context) -> Result<Async<Option<T>>, Never> {
+        let SourceStream {
+            ref mut create_source,
+            ref mut source,
+            ..
+        } = *self;
+
+        if let Some(create_source) = create_source.take() {
+            let main_context = MainContext::ref_thread_default();
+            match main_context {
+                None => unreachable!(),
+                Some(ref main_context) => {
+                    assert!(main_context.is_owner());
+
+                    // Channel for sending back the Source result to our future here.
+                    //
+                    // In theory we could directly continue polling the
+                    // corresponding task from the Source callback,
+                    // however this would break at the very least
+                    // the g_main_current_source() API.
+                    let (send, recv) = mpsc::unbounded();
+
+                    let s = create_source(send);
+
+                    s.attach(Some(main_context));
+                    *source = Some((s, recv));
+                }
+            }
+        }
+
+        // At this point we must have a receiver
+        let res = {
+            let &mut (_, ref mut receiver) = source.as_mut().unwrap();
+            receiver.poll_next(ctx)
+        };
+        match res {
+            Err(_) => unreachable!(),
+            Ok(Async::Ready(v)) => {
+                if v.is_none() {
+                    // Get rid of the reference to the source, it triggered
+                    let _ = source.take();
+                }
+                Ok(Async::Ready(v))
+            }
+            Ok(Async::Pending) => Ok(Async::Pending),
+        }
+    }
+}
+
+impl<T, F> Drop for SourceStream<T, F> {
+    fn drop(&mut self) {
+        // Get rid of the source, we don't care anymore if it still triggers
+        if let Some((source, _)) = self.source.take() {
+            source.destroy();
+        }
+    }
+}
+
+pub fn interval_stream(value: u32) -> Box<Stream<Item = (), Error = Never>> {
+    interval_stream_with_priority(::PRIORITY_DEFAULT, value)
+}
+
+pub fn interval_stream_with_priority(priority: Priority, value: u32) -> Box<Stream<Item = (), Error = Never>> {
+    SourceStream::new(move |send| {
+        ::timeout_source_new(value, None, priority, move || {
+            if send.unbounded_send(()).is_err() {
+                Continue(false)
+            } else {
+                Continue(true)
+            }
+        })
+    })
+}
+
+
+pub fn interval_stream_seconds(value: u32) -> Box<Stream<Item = (), Error = Never>> {
+    interval_stream_seconds_with_priority(::PRIORITY_DEFAULT, value)
+}
+
+pub fn interval_stream_seconds_with_priority(priority: Priority, value: u32) -> Box<Stream<Item = (), Error = Never>> {
+    SourceStream::new(move |send| {
+        ::timeout_source_new_seconds(value, None, priority, move || {
+            if send.unbounded_send(()).is_err() {
+                Continue(false)
+            } else {
+                Continue(true)
+            }
+        })
+    })
+}

--- a/src/source_futures.rs
+++ b/src/source_futures.rs
@@ -263,3 +263,46 @@ pub fn interval_stream_seconds_with_priority(priority: Priority, value: u32) -> 
         })
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::FutureExt;
+    use futures_util::StreamExt;
+
+    #[test]
+    fn test_timeout() {
+        let mut c = MainContext::new();
+
+        let res = c.block_on(timeout_future(20)
+            .and_then(move |_ctx| {
+                Ok(())
+            })
+        );
+
+        assert_eq!(res, Ok(()));
+    }
+
+    #[test]
+    fn test_interval() {
+        let mut c = MainContext::new();
+
+        let mut count = 0;
+
+        {
+            let count = &mut count;
+            let res = c.block_on(interval_stream(20)
+                .take(2)
+                .for_each(move |_ctx| {
+                    *count = *count + 1;
+                    Ok(())
+                })
+                .map(|_| ())
+            );
+
+            assert_eq!(res, Ok(()));
+        }
+
+        assert_eq!(count, 2);
+    }
+}

--- a/src/source_futures.rs
+++ b/src/source_futures.rs
@@ -53,9 +53,9 @@ where
         if let Some(create_source) = create_source.take() {
             let main_context = MainContext::ref_thread_default();
             match main_context {
-                None => unreachable!(),
+                None => panic!("Polled from an Executor not backed by a GLib main context"),
                 Some(ref main_context) => {
-                    assert!(main_context.is_owner());
+                    assert!(main_context.is_owner(), "Spawning futures only allowed if the thread is owning the MainContext");
 
                     // Channel for sending back the Source result to our future here.
                     //
@@ -79,7 +79,7 @@ where
             receiver.poll(ctx)
         };
         match res {
-            Err(_) => unreachable!(),
+            Err(_) => panic!("Source sender was unexpectedly closed"),
             Ok(Async::Ready(v)) => {
                 // Get rid of the reference to the source, it triggered
                 let _ = source.take();
@@ -225,9 +225,9 @@ where
         if let Some(create_source) = create_source.take() {
             let main_context = MainContext::ref_thread_default();
             match main_context {
-                None => unreachable!(),
+                None => panic!("Polled from an Executor not backed by a GLib main context"),
                 Some(ref main_context) => {
-                    assert!(main_context.is_owner());
+                    assert!(main_context.is_owner(), "Spawning futures only allowed if the thread is owning the MainContext");
 
                     // Channel for sending back the Source result to our future here.
                     //
@@ -251,7 +251,7 @@ where
             receiver.poll_next(ctx)
         };
         match res {
-            Err(_) => unreachable!(),
+            Err(_) => panic!("Source sender was unexpectedly closed"),
             Ok(Async::Ready(v)) => {
                 if v.is_none() {
                     // Get rid of the reference to the source, it triggered


### PR DESCRIPTION
This Executor will also be used in GIO later for Futures around the async operations (and GSources)