### PR TITLE
Mark g_main_context_default as non-nullable.

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -329,6 +329,11 @@ concurrency = "send+sync"
        # source id is a newtype
        ignore = true
 
+       [[object.function]]
+       name = "default"
+           [object.function.return]
+           nullable = false
+
 [[object]]
 name = "GLib.MainLoop"
 status = "generate"

--- a/src/auto/main_context.rs
+++ b/src/auto/main_context.rs
@@ -124,7 +124,7 @@ impl MainContext {
         }
     }
 
-    pub fn default() -> Option<MainContext> {
+    pub fn default() -> MainContext {
         unsafe {
             from_glib_none(ffi::g_main_context_default())
         }

--- a/src/main_context.rs
+++ b/src/main_context.rs
@@ -68,8 +68,8 @@ mod tests {
 
     #[test]
     fn test_invoke() {
-        let l = ::MainLoop::new(None, false);
-        let c = MainContext::default().unwrap();
+        let c = MainContext::new();
+        let l = ::MainLoop::new(&c, false);
 
         let l_clone = l.clone();
         thread::spawn(move || {


### PR DESCRIPTION
The default main context is always available and non-null. Also run
test in a new separate context to avoid interference between tests.