### PR TITLE
Fix spawn_check_exit status to make sense and return bool

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -271,6 +271,10 @@ status = "generate"
     pattern = "POLLFD_FORMAT"
     #for C printf
     ignore = true
+    [[object.function]]
+    name = "spawn_check_exit_status"
+    #boolean return value needs to be returned
+    ignore = true    
 
 [[object]]
 name = "GLib.Checksum"

--- a/src/auto/functions.rs
+++ b/src/auto/functions.rs
@@ -1080,15 +1080,6 @@ pub fn spaced_primes_closest(num: u32) -> u32 {
 //    unsafe { TODO: call ffi::g_spawn_async_with_pipes() }
 //}
 
-#[cfg(any(feature = "v2_34", feature = "dox"))]
-pub fn spawn_check_exit_status(exit_status: i32) -> Result<(), Error> {
-    unsafe {
-        let mut error = ptr::null_mut();
-        let _ = ffi::g_spawn_check_exit_status(exit_status, &mut error);
-        if error.is_null() { Ok(()) } else { Err(from_glib_full(error)) }
-    }
-}
-
 #[cfg(any(unix, feature = "dox"))]
 pub fn spawn_command_line_async(command_line: &str) -> Result<(), Error> {
     unsafe {

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -1,0 +1,17 @@
+#[cfg(any(feature = "v2_34", feature = "dox"))]
+use Error;
+#[cfg(any(feature = "v2_34", feature = "dox"))]
+use ffi;
+#[cfg(any(feature = "v2_34", feature = "dox"))]
+use std::ptr;
+#[cfg(any(feature = "v2_34", feature = "dox"))]
+use translate::*;
+
+#[cfg(any(feature = "v2_34", feature = "dox"))]
+pub fn spawn_check_exit_status(exit_status: i32) -> Result<bool, Error> {
+    unsafe {
+        let mut error = ptr::null_mut();
+        let ret = ffi::g_spawn_check_exit_status(exit_status, &mut error);
+        if error.is_null() { Ok(from_glib(ret)) } else { Err(from_glib_full(error)) }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,8 @@ pub use char::*;
 mod checksum;
 pub mod closure;
 pub mod error;
+pub mod functions;
+pub use functions::*;
 mod enums;
 mod file_error;
 mod key_file;


### PR DESCRIPTION
I'm not sure who is going to be calling this function, but it's a little silly to have it returning a `Result<(), Error>` which can't provide the caller with any useful information.  This fixes the return value.

I ended up adding a new file, `src/functions.rs` with only this one function in it.