### PR TITLE
Add support for bindings

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -1,0 +1,89 @@
+// Copyright 2018, The Gtk-rs Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+use std::mem;
+use std::ptr;
+
+use {BindingFlags, Closure};
+use ffi as glib_ffi;
+use gobject_ffi;
+use object::{IsA, Object};
+use translate::{FromGlib, ToGlib, ToGlibPtr, ToGlibPtrMut, FromGlibPtrFull, Stash, from_glib_none};
+
+glib_wrapper! {
+    pub struct Binding(Object<gobject_ffi::GBinding>);
+
+    match fn {
+        get_type => || gobject_ffi::g_binding_get_type(),
+    }
+}
+
+pub trait BindingExt {
+    fn bind_property<S: IsA<Object>, T: IsA<Object>>(source: &S, source_property: &str, target: &T, target_property: &str, flags: BindingFlags) -> Self;
+    fn bind_property_with_closures<S: IsA<Object>, T: IsA<Object>>(source: &S, source_property: &str, target: &T, target_property: &str, flags: BindingFlags, transform_to: Closure, transform_from: Closure) -> Self;
+    fn get_flags(&self) -> BindingFlags;
+    fn get_source(&self) -> Object;
+    fn get_source_property(&self) -> String;
+    fn get_target(&self) -> Object;
+    fn get_target_property(&self) -> String;
+    #[cfg(any(feature = "v2_38"))]
+    fn unbind(&self);
+}
+
+impl BindingExt for Binding {
+    fn bind_property<S: IsA<Object>, T: IsA<Object>>(source: &S, source_property: &str, target: &T, target_property: &str, flags: BindingFlags) -> Self {
+        unsafe {
+            let gbinding = gobject_ffi::g_object_bind_property(source.to_glib_none().0,
+                source_property.to_glib_none().0, target.to_glib_none().0, target_property.to_glib_none().0,
+                flags.to_glib());
+            from_glib_none(gbinding)
+        }
+    }
+
+    fn bind_property_with_closures<S: IsA<Object>, T: IsA<Object>>(source: &S, source_property: &str, target: &T, target_property: &str, flags: BindingFlags, transform_to: Closure, transform_from: Closure) -> Self {
+        unsafe {
+            let gbinding = gobject_ffi::g_object_bind_property_with_closures(source.to_glib_none().0,
+                source_property.to_glib_none().0, target.to_glib_none().0, target_property.to_glib_none().0,
+                flags.to_glib(), transform_to.to_glib_none().0, transform_from.to_glib_none().0);
+            from_glib_none(gbinding)
+        }
+    }
+
+    fn get_flags(&self) -> BindingFlags {
+        unsafe {
+            FromGlib::from_glib(gobject_ffi::g_binding_get_flags(self.to_glib_none().0))
+        }
+    }
+
+    fn get_source(&self) -> Object {
+        unsafe {
+            from_glib_none(gobject_ffi::g_binding_get_target(self.to_glib_none().0))
+        }
+    }
+
+    fn get_source_property(&self) -> String {
+        unsafe {
+            from_glib_none(gobject_ffi::g_binding_get_source_property(self.to_glib_none().0))
+        }
+    }
+
+    fn get_target(&self) -> Object {
+        unsafe {
+            from_glib_none(gobject_ffi::g_binding_get_target(self.to_glib_none().0))
+        }
+    }
+
+    fn get_target_property(&self) -> String {
+        unsafe {
+            from_glib_none(gobject_ffi::g_binding_get_target_property(self.to_glib_none().0))
+        }
+    }
+
+    #[cfg(any(feature = "v2_38"))]
+    fn unbind(&self) {
+        unsafe {
+            gobject_ffi::g_binding_unbind(self.to_glib_none().0);
+        }
+    }
+}

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -11,6 +11,43 @@ use value::Value;
 use std::cmp;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum BindingFlags {
+    Default,
+    Bidirectional,
+    SyncCreate,
+    InvertBoolean,
+    __Unknown(u32),
+}
+
+#[doc(hidden)]
+impl ToGlib for BindingFlags {
+    type GlibType = gobject_ffi::GBindingFlags;
+
+    fn to_glib(&self) -> gobject_ffi::GBindingFlags {
+        match *self {
+            BindingFlags::Default => gobject_ffi::G_BINDING_DEFAULT,
+            BindingFlags::Bidirectional => gobject_ffi::G_BINDING_BIDIRECTIONAL,
+            BindingFlags::SyncCreate => gobject_ffi::G_BINDING_SYNC_CREATE,
+            BindingFlags::InvertBoolean => gobject_ffi::G_BINDING_INVERT_BOOLEAN,
+            BindingFlags::__Unknown(value) => value
+        }
+    }
+}
+
+#[doc(hidden)]
+impl FromGlib<gobject_ffi::GBindingFlags> for BindingFlags {
+    fn from_glib(value: gobject_ffi::GBindingFlags) -> Self {
+        match value {
+            0 => BindingFlags::Default,
+            1 => BindingFlags::Bidirectional,
+            2 => BindingFlags::SyncCreate,
+            4 => BindingFlags::InvertBoolean,
+            value => BindingFlags::__Unknown(value),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum UserDirectory {
     Desktop,
     Documents,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,7 @@ extern crate futures_channel;
 extern crate futures_util;
 
 use std::ffi::CStr;
+pub use binding::{Binding, BindingExt};
 pub use bytes::Bytes;
 pub use closure::Closure;
 pub use error::{Error, BoolError};
@@ -137,6 +138,7 @@ pub use time_val::{
     get_current_time,
 };
 pub use enums::{
+    BindingFlags,
     UserDirectory,
     EnumClass,
     EnumValue,
@@ -162,6 +164,7 @@ pub use auto::functions::*;
 #[allow(non_upper_case_globals)]
 mod auto;
 
+pub mod binding;
 mod bytes;
 pub mod char;
 pub use char::*;


### PR DESCRIPTION
I tried testing this but I'm not able anymore to use my local copy of a gtk-rs crate.
For this example, I have the error:
```
error[E0277]: the trait bound `gtk::Entry: glib::IsA<glib::Object>` is not satisfied
```
which might be caused by having multiple glib crates.
Could you please help me to test this PR?
Thanks.