### PR TITLE
Add a new futures-nightly feature that uses futures-stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ futures-core = { version = "0.2", optional = true }
 futures-executor = { version = "0.2", optional = true }
 futures-channel = { version = "0.2", optional = true }
 futures-util = { version = "0.2", optional = true }
+futures-stable = { version = "0.2", optional = true }
 
 [dependencies.glib-sys]
 version = "0.6.0"
@@ -48,4 +49,5 @@ v2_50 = ["v2_48", "glib-sys/v2_50"]
 v2_52 = ["v2_50", "glib-sys/v2_52"]
 v2_54 = ["v2_52", "glib-sys/v2_54", "gobject-sys/v2_54"]
 futures = ["futures-core", "futures-executor", "futures-channel", "futures-util", "v2_36"]
+futures-nightly = ["futures", "futures-core/nightly", "futures-stable", "futures-stable/nightly"]
 dox = ["glib-sys/dox", "gobject-sys/dox"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
+#![cfg_attr(feature = "futures-nightly", feature(pin))]
+
 //! # **glib**, **gobject** and **gio** bindings for Rust
 //!
 //! This library contains
@@ -89,6 +91,8 @@ extern crate futures_executor;
 extern crate futures_channel;
 #[cfg(feature="futures")]
 extern crate futures_util;
+#[cfg(feature="futures-nightly")]
+extern crate futures_stable;
 
 use std::ffi::CStr;
 pub use bytes::Bytes;


### PR DESCRIPTION
This allows using async-await when enabled, but requires nightly for now.