### PR TITLE
Only use from_glib_none() in Object::new() if the object is actually …

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -613,7 +613,7 @@ impl Object {
             let ptr = gobject_ffi::g_object_newv(type_.to_glib(), params_c.len() as u32, mut_override(params_c.as_ptr()));
             if ptr.is_null() {
                 Err(BoolError("Can't instantiate object"))
-            } else if type_.is_a(&from_glib(gobject_ffi::g_initially_unowned_get_type())) {
+            } else if gobject_ffi::g_object_is_floating(ptr) != glib_ffi::GFALSE {
                 Ok(from_glib_none(ptr))
             } else {
                 Ok(from_glib_full(ptr))


### PR DESCRIPTION
…floating

Some GObjects are based on GInitiallyUnowned but their constructor
functions return an already sunken floating reference.