### PR TITLE
Use futures-preview crates instead of futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,11 @@ name = "glib"
 lazy_static = "1.0"
 libc = "0.2"
 bitflags = "1.0"
-futures-core = { version = "0.2", optional = true }
-futures-executor = { version = "0.2", optional = true }
-futures-channel = { version = "0.2", optional = true }
-futures-util = { version = "0.2", optional = true }
-futures-stable = { version = "0.2", optional = true }
+futures-core-preview = { version = "0.2", optional = true }
+futures-executor-preview = { version = "0.2", optional = true }
+futures-channel-preview = { version = "0.2", optional = true }
+futures-util-preview = { version = "0.2", optional = true }
+futures-stable-preview = { version = "0.2", optional = true }
 
 [dependencies.glib-sys]
 version = "0.6.0"
@@ -52,6 +52,6 @@ v2_48 = ["v2_46", "glib-sys/v2_48"]
 v2_50 = ["v2_48", "glib-sys/v2_50"]
 v2_52 = ["v2_50", "glib-sys/v2_52"]
 v2_54 = ["v2_52", "glib-sys/v2_54", "gobject-sys/v2_54"]
-futures = ["futures-core", "futures-executor", "futures-channel", "futures-util", "v2_36"]
-futures-nightly = ["futures", "futures-core/nightly", "futures-stable", "futures-stable/nightly"]
+futures = ["futures-core-preview", "futures-executor-preview", "futures-channel-preview", "futures-util-preview", "v2_36"]
+futures-nightly = ["futures", "futures-core-preview/nightly", "futures-stable-preview", "futures-stable-preview/nightly"]
 dox = ["glib-sys/dox", "gobject-sys/dox"]


### PR DESCRIPTION
The futures crates were janked from crates.io and renamed to
futures-preview for whatever reason.


The other crates and gir need to be updated next. Useless code churn.

See https://users.rust-lang.org/t/futures-0-2-has-been-moved-to-futures-preview/18329 for context