### PR TITLE
Allow for safe get_type() functions without warnings for an unused un…

### DIFF
--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -22,6 +22,7 @@ macro_rules! glib_boxed_wrapper {
 
         impl $crate::types::StaticType for $name {
             fn static_type() -> $crate::types::Type {
+                #[allow(unused_unsafe)]
                 unsafe { $crate::translate::from_glib($get_type_expr) }
             }
         }

--- a/src/object.rs
+++ b/src/object.rs
@@ -446,6 +446,7 @@ macro_rules! glib_object_wrapper {
 
         impl $crate::types::StaticType for $name {
             fn static_type() -> $crate::types::Type {
+                #[allow(unused_unsafe)]
                 unsafe { $crate::translate::from_glib($get_type_expr) }
             }
         }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -21,6 +21,7 @@ macro_rules! glib_shared_wrapper {
 
         impl $crate::types::StaticType for $name {
             fn static_type() -> $crate::types::Type {
+                #[allow(unused_unsafe)]
                 unsafe { $crate::translate::from_glib($get_type_expr) }
             }
         }


### PR DESCRIPTION
…safe block

This happens when declaring new types from Rust.