### PR TITLE
Implement SendUniqueCell and corresponding SendUnique trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,12 @@ pub use param_spec::ParamSpec;
 mod quark;
 pub use quark::Quark;
 
+pub mod send_unique;
+pub use send_unique::{
+    SendUniqueCell,
+    SendUnique,
+};
+
 #[cfg(feature="futures")]
 mod main_context_futures;
 #[cfg(feature="futures")]

--- a/src/object.rs
+++ b/src/object.rs
@@ -788,6 +788,8 @@ pub trait ObjectExt: IsA<Object> {
     fn downgrade(&self) -> WeakRef<Self>;
 
     fn bind_property<'a, O: IsA<Object>, N: Into<&'a str>, M: Into<&'a str>>(&'a self, source_property: N, target: &'a O, target_property: M) -> BindingBuilder<'a, Self, O>;
+
+    fn ref_count(&self) -> u32;
 }
 
 impl<T: IsA<Object> + SetValue> ObjectExt for T {
@@ -1112,6 +1114,13 @@ impl<T: IsA<Object> + SetValue> ObjectExt for T {
         let target_property = target_property.into();
 
         BindingBuilder::new(self, source_property, target, target_property)
+    }
+
+    fn ref_count(&self) -> u32 {
+        let stash = self.to_glib_none();
+        let ptr: *mut gobject_ffi::GObject = stash.0;
+
+        unsafe { glib_ffi::g_atomic_int_get(&(*ptr).ref_count as *const u32 as *const i32) as u32 }
     }
 }
 

--- a/src/send_unique.rs
+++ b/src/send_unique.rs
@@ -1,0 +1,139 @@
+// Copyright 2018, The Gtk-rs Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+use std::ops;
+use std::cell::RefCell;
+
+/// Like `Send` but only if we have the unique reference to the object
+pub unsafe trait SendUnique: 'static {
+    fn is_unique(&self) -> bool;
+}
+
+/// Allows sending reference counted objects that don't implement `Send` to other threads
+/// as long as only a single reference to the object exists.
+#[derive(Debug)]
+pub struct SendUniqueCell<T: SendUnique> {
+    obj: T,
+    // Thread id and refcount
+    thread: RefCell<Option<(usize, usize)>>,
+}
+
+unsafe impl<T: SendUnique> Send for SendUniqueCell<T> {}
+
+#[derive(Debug)]
+pub struct BorrowError;
+
+impl<T: SendUnique> SendUniqueCell<T> {
+    /// Create a new `SendUniqueCell` out of `obj`
+    ///
+    /// Fails if `obj` is not unique at this time
+    pub fn new(obj: T) -> Result<Self, T> {
+        if !obj.is_unique() {
+            return Err(obj);
+        }
+
+        Ok(SendUniqueCell {
+            obj,
+            thread: RefCell::new(None),
+        })
+    }
+
+    /// Borrow the contained object or panic if borrowing
+    /// is not possible at this time
+    pub fn borrow(&self) -> Ref<T> {
+        match self.try_borrow() {
+            Err(_) => panic!("Can't borrow"),
+            Ok(r) => r,
+        }
+    }
+
+    /// Try borrowing the contained object
+    ///
+    /// Borrowing is possible as long as only a single reference
+    /// to the object exists, or it is borrowed from the same
+    /// thread currently
+    pub fn try_borrow(&self) -> Result<Ref<T>, BorrowError> {
+        let mut thread = self.thread.borrow_mut();
+
+        // If the object is unique, we can borrow it from
+        // any thread we want and just have to keep track
+        // how often we borrowed it
+        if self.obj.is_unique() {
+            if *thread == None {
+                *thread = Some((::get_thread_id(), 1));
+            } else {
+                thread.as_mut().unwrap().1 += 1;
+            }
+
+            return Ok(Ref(self));
+        }
+
+        // If we don't even know from which thread it is borrowed, this
+        // means it somehow got borrowed from outside the SendUniqueCell
+        if *thread == None {
+            return Err(BorrowError);
+        }
+
+        // If the object is not unique, we can only borrow it
+        // from the thread that currently has it borrowed
+        if thread.as_ref().unwrap().0 != ::get_thread_id() {
+            return Err(BorrowError);
+        }
+
+        thread.as_mut().unwrap().1 += 1;
+
+        Ok(Ref(self))
+    }
+
+    /// Extract the contained object or panic if it is not possible
+    /// at this time
+    pub fn into_inner(self) -> T {
+        match self.try_into_inner() {
+            Err(_) => panic!("Can't convert into inner type"),
+            Ok(obj) => obj,
+        }
+    }
+
+    /// Try extracing the contained object
+    ///
+    /// Borrowing is possible as long as only a single reference
+    /// to the object exists, or it is borrowed from the same
+    /// thread currently
+    pub fn try_into_inner(self) -> Result<T, Self> {
+        if self.try_borrow().is_err() {
+            Err(self)
+        } else {
+            Ok(self.obj)
+        }
+    }
+}
+
+pub struct Ref<'a, T: SendUnique>(&'a SendUniqueCell<T>);
+
+impl<'a, T: SendUnique> AsRef<T> for Ref<'a, T> {
+    fn as_ref(&self) -> &T {
+        &self.0.obj
+    }
+}
+
+impl<'a, T: SendUnique> ops::Deref for Ref<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0.obj
+    }
+}
+
+impl<'a, T: SendUnique> Drop for Ref<'a, T> {
+    fn drop(&mut self) {
+        let is_unique = self.0.obj.is_unique();
+        let mut thread = self.0.thread.borrow_mut();
+
+        if is_unique && thread.as_ref().unwrap().1 == 1 {
+            *thread = None;
+        } else {
+            thread.as_mut().unwrap().1 -= 1;
+        }
+    }
+}


### PR DESCRIPTION
This allows sending reference counted objects to different threads as
long as only a single reference to the object exists.

----

See here for an example usage: https://github.com/sdroege/gstreamer-rs/blob/e8db89464ed51148a710d54c9969e076f3aba702/examples/src/bin/pango-cairo.rs

I plan to add this as another "concurrency" mode to gir, and then most of GIO can be Send-able via this. For Pango this is unfortunately not the case as the layout has a reference to the context (and the context to the fontmap) and uses those, so the refcount of the layout itself is not sufficient for sendability.

That is, this needs very careful investigation for enabling on reference counted objects.