### PR TITLE
Remove futures-nightly feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ futures-core-preview = { version = "0.2", optional = true }
 futures-executor-preview = { version = "0.2", optional = true }
 futures-channel-preview = { version = "0.2", optional = true }
 futures-util-preview = { version = "0.2", optional = true }
-futures-stable-preview = { version = "0.2", optional = true }
 
 glib-sys = { git = "https://github.com/gtk-rs/sys" }
 gobject-sys = { git = "https://github.com/gtk-rs/sys" }
@@ -49,5 +48,4 @@ v2_52 = ["v2_50", "glib-sys/v2_52"]
 v2_54 = ["v2_52", "glib-sys/v2_54", "gobject-sys/v2_54"]
 v2_56 = ["v2_54", "glib-sys/v2_56"]
 futures = ["futures-core-preview", "futures-executor-preview", "futures-channel-preview", "futures-util-preview", "v2_36"]
-futures-nightly = ["futures", "futures-core-preview/nightly", "futures-stable-preview", "futures-stable-preview/nightly"]
 dox = ["glib-sys/dox", "gobject-sys/dox"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,6 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
-#![cfg_attr(feature = "futures-nightly", feature(pin))]
-
 //! # **glib**, **gobject** and **gio** bindings for Rust
 //!
 //! This library contains
@@ -91,8 +89,6 @@ extern crate futures_executor;
 extern crate futures_channel;
 #[cfg(feature="futures")]
 extern crate futures_util;
-#[cfg(feature="futures-nightly")]
-extern crate futures_stable;
 
 use std::ffi::CStr;
 pub use bytes::Bytes;

--- a/src/main_context_futures.rs
+++ b/src/main_context_futures.rs
@@ -12,22 +12,12 @@ use futures_core::{Async, Future, Never};
 use futures_executor;
 use futures_util::future::FutureExt;
 
-#[cfg(feature = "futures-nightly")]
-use futures_stable::{StableFuture, StableExecutor};
-#[cfg(feature = "futures-nightly")]
-use std::boxed::PinBox;
-
 use MainContext;
 use MainLoop;
 use Source;
 use Priority;
 
 use get_thread_id;
-
-#[cfg(feature = "futures-nightly")]
-type StoredFutureBox<T> = PinBox<T>;
-#[cfg(not(feature = "futures-nightly"))]
-type StoredFutureBox<T> = Box<T>;
 
 use ::translate::{from_glib_none, from_glib_full, mut_override, ToGlib};
 use ffi as glib_ffi;
@@ -41,7 +31,7 @@ const DONE: usize = 3;
 #[repr(C)]
 struct TaskSource {
     source: glib_ffi::GSource,
-    future: Option<(StoredFutureBox<Future<Item = (), Error = Never>>, Box<LocalMap>)>,
+    future: Option<(Box<Future<Item = (), Error = Never>>, Box<LocalMap>)>,
     thread: Option<usize>,
     state: AtomicUsize,
 }
@@ -150,7 +140,7 @@ static SOURCE_FUNCS: glib_ffi::GSourceFuncs = glib_ffi::GSourceFuncs {
 impl TaskSource {
     fn new(
         priority: Priority,
-        future: StoredFutureBox<Future<Item = (), Error = Never> + 'static + Send>,
+        future: Box<Future<Item = (), Error = Never> + 'static + Send>,
     ) -> Source {
         unsafe { Self::new_unsafe(priority, None, future) }
     }
@@ -160,7 +150,7 @@ impl TaskSource {
     unsafe fn new_unsafe(
         priority: Priority,
         thread: Option<usize>,
-        future: StoredFutureBox<Future<Item = (), Error = Never> + 'static>,
+        future: Box<Future<Item = (), Error = Never> + 'static>,
     ) -> Source {
         let source = glib_ffi::g_source_new(
             mut_override(&SOURCE_FUNCS),
@@ -230,96 +220,6 @@ impl TaskSource {
     }
 }
 
-#[cfg(feature = "futures-nightly")]
-impl MainContext {
-    /// Spawn a new infallible `Future` on the main context.
-    ///
-    /// This can be called from any thread and will execute the future from the thread
-    /// where main context is running, e.g. via a `MainLoop`.
-    pub fn spawn<F: StableFuture<Item = (), Error = Never> + Send + 'static>(&self, f: F) {
-        self.spawn_with_priority(::PRIORITY_DEFAULT, f);
-    }
-
-    /// Spawn a new infallible `Future` on the main context.
-    ///
-    /// The given `Future` does not have to be `Send`.
-    ///
-    /// This can be called only from the thread where the main context is running, e.g.
-    /// from any other `Future` that is executed on this main context, or after calling
-    /// `push_thread_default` or `acquire` on the main context.
-    pub fn spawn_local<F: StableFuture<Item = (), Error = Never> + 'static>(&self, f: F) {
-        self.spawn_local_with_priority(::PRIORITY_DEFAULT, f);
-    }
-
-    /// Spawn a new infallible `Future` on the main context, with a non-default priority.
-    ///
-    /// This can be called from any thread and will execute the future from the thread
-    /// where main context is running, e.g. via a `MainLoop`.
-    pub fn spawn_with_priority<F: StableFuture<Item = (), Error = Never> + Send + 'static>(&self, priority: Priority, f: F) {
-        let f = f.pin();
-        let source = TaskSource::new(priority, f);
-        source.attach(Some(&*self));
-    }
-
-    /// Spawn a new infallible `Future` on the main context, with a non-default priority.
-    ///
-    /// The given `Future` does not have to be `Send`.
-    ///
-    /// This can be called only from the thread where the main context is running, e.g.
-    /// from any other `Future` that is executed on this main context, or after calling
-    /// `push_thread_default` or `acquire` on the main context.
-    pub fn spawn_local_with_priority<F: StableFuture<Item = (), Error = Never> + 'static>(&self, priority: Priority, f: F) {
-        assert!(self.is_owner(), "Spawning local futures only allowed on the thread owning the MainContext");
-        let f = f.pin_local();
-        unsafe {
-            // Ensure that this task is never polled on another thread
-            // than this one where it was spawned now.
-            let source = TaskSource::new_unsafe(priority, Some(get_thread_id()), f);
-            source.attach(Some(&*self));
-        }
-    }
-
-    /// Runs a new, infallible `Future` on the main context and block until it finished, returning
-    /// the result of the `Future`.
-    ///
-    /// The given `Future` does not have to be `Send` or `'static`.
-    ///
-    /// This must only be called if no `MainLoop` or anything else is running on this specific main
-    /// context.
-    pub fn block_on<F: StableFuture>(&self, f: F) -> Result<F::Item, F::Error> {
-        let mut res = None;
-        let l = MainLoop::new(Some(&*self), false);
-        let l_clone = l.clone();
-
-        unsafe {
-            let f = f.pin_local();
-
-            let f = f.then(|r| {
-                res = Some(r);
-                l_clone.quit();
-                Ok::<(), Never>(())
-            });
-
-            let f: *mut Future<Item = (), Error = Never> = Box::into_raw(Box::new(f));
-            // XXX: Transmute to get a 'static lifetime here, super unsafe
-            let f: *mut (Future<Item = (), Error = Never> + 'static) = mem::transmute(f);
-            let f: Box<Future<Item = (), Error = Never> + 'static> = Box::from_raw(f);
-
-            let f = f.pin_local();
-
-            // Ensure that this task is never polled on another thread
-            // than this one where it was spawned now.
-            let source = TaskSource::new_unsafe(::PRIORITY_DEFAULT, Some(get_thread_id()), f);
-            source.attach(Some(&*self));
-        }
-
-        l.run();
-
-        res.unwrap()
-    }
-}
-
-#[cfg(not(feature = "futures-nightly"))]
 impl MainContext {
     /// Spawn a new infallible `Future` on the main context.
     ///
@@ -404,29 +304,9 @@ impl MainContext {
     }
 }
 
-#[cfg(feature = "futures-nightly")]
-impl Executor for MainContext {
-    fn spawn(&mut self, f: Box<Future<Item = (), Error = Never> + Send>) -> Result<(), SpawnError> {
-        let f = f.pin();
-        let source = TaskSource::new(::PRIORITY_DEFAULT, f);
-        source.attach(Some(&*self));
-        Ok(())
-    }
-}
-
-#[cfg(not(feature = "futures-nightly"))]
 impl Executor for MainContext {
     fn spawn(&mut self, f: Box<Future<Item = (), Error = Never> + Send>) -> Result<(), SpawnError> {
         let f = Box::new(f);
-        let source = TaskSource::new(::PRIORITY_DEFAULT, f);
-        source.attach(Some(&*self));
-        Ok(())
-    }
-}
-
-#[cfg(feature = "futures-nightly")]
-impl StableExecutor for MainContext {
-    fn spawn_pinned(&mut self, f: PinBox<Future<Item = (), Error = Never> + Send>) -> Result<(), SpawnError> {
         let source = TaskSource::new(::PRIORITY_DEFAULT, f);
         source.attach(Some(&*self));
         Ok(())


### PR DESCRIPTION
futures 0.2 is not maintained anymore and the nightly parts don't work
anymore with latest nightly toolchain

----

If I understand how to optionally depend (based on a feature flag) on futures 0.3, I'll re-add this in a different way.

Does someone know how that would look like in `Cargo.toml`?