### PR TITLE
Move to the futures crate instead of individual crates and re-export …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,7 @@ name = "glib"
 lazy_static = "1.0"
 libc = "0.2"
 bitflags = "1.0"
-futures-core-preview = { version = "0.2", optional = true }
-futures-executor-preview = { version = "0.2", optional = true }
-futures-channel-preview = { version = "0.2", optional = true }
-futures-util-preview = { version = "0.2", optional = true }
+futures-preview = { version = "0.2", optional = true }
 
 glib-sys = { git = "https://github.com/gtk-rs/sys" }
 gobject-sys = { git = "https://github.com/gtk-rs/sys" }
@@ -47,5 +44,5 @@ v2_50 = ["v2_48", "glib-sys/v2_50"]
 v2_52 = ["v2_50", "glib-sys/v2_52"]
 v2_54 = ["v2_52", "glib-sys/v2_54", "gobject-sys/v2_54"]
 v2_56 = ["v2_54", "glib-sys/v2_56"]
-futures = ["futures-core-preview", "futures-executor-preview", "futures-channel-preview", "futures-util-preview", "v2_36"]
+futures = ["futures-preview", "v2_36"]
 dox = ["glib-sys/dox", "gobject-sys/dox"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,13 +82,7 @@ extern crate glib_sys as ffi;
 extern crate gobject_sys as gobject_ffi;
 
 #[cfg(feature="futures")]
-extern crate futures_core;
-#[cfg(feature="futures")]
-extern crate futures_executor;
-#[cfg(feature="futures")]
-extern crate futures_channel;
-#[cfg(feature="futures")]
-extern crate futures_util;
+pub extern crate futures;
 
 use std::ffi::CStr;
 pub use bytes::Bytes;

--- a/src/main_context_futures.rs
+++ b/src/main_context_futures.rs
@@ -5,12 +5,11 @@
 use std::mem;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use futures_core;
-use futures_core::executor::{Executor, SpawnError};
-use futures_core::task::{LocalMap, UnsafeWake, Waker};
-use futures_core::{Async, Future, Never};
-use futures_executor;
-use futures_util::future::FutureExt;
+use futures;
+use futures::prelude::*;
+use futures::executor::{Executor, SpawnError};
+use futures::task::{LocalMap, UnsafeWake, Waker};
+use futures::{Async, Future, Never};
 
 use MainContext;
 use MainLoop;
@@ -201,9 +200,9 @@ impl TaskSource {
             executor.push_thread_default();
 
             let res = {
-                let enter = futures_executor::enter().unwrap();
+                let enter = futures::executor::enter().unwrap();
                 let mut context =
-                    futures_core::task::Context::new(local_map, &waker, &mut executor);
+                    futures::task::Context::new(local_map, &waker, &mut executor);
 
                 let res = future.poll(&mut context).unwrap_or(Async::Ready(()));
 

--- a/src/source_futures.rs
+++ b/src/source_futures.rs
@@ -2,10 +2,9 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
-use futures_channel::{mpsc, oneshot};
-use futures_core::stream::Stream;
-use futures_core::task::Context;
-use futures_core::{Async, Future, Never};
+use futures::prelude::*;
+use futures::channel::{mpsc, oneshot};
+use futures::task;
 
 use MainContext;
 use Source;
@@ -43,7 +42,7 @@ where
     type Item = T;
     type Error = Never;
 
-    fn poll(&mut self, ctx: &mut Context) -> Result<Async<T>, Never> {
+    fn poll(&mut self, ctx: &mut task::Context) -> Result<Async<T>, Never> {
         let SourceFuture {
             ref mut create_source,
             ref mut source,
@@ -210,7 +209,7 @@ where
     type Item = T;
     type Error = Never;
 
-    fn poll_next(&mut self, ctx: &mut Context) -> Result<Async<Option<T>>, Never> {
+    fn poll_next(&mut self, ctx: &mut task::Context) -> Result<Async<Option<T>>, Never> {
         let SourceStream {
             ref mut create_source,
             ref mut source,
@@ -334,8 +333,6 @@ pub fn unix_signal_stream_with_priority(priority: Priority, signum: i32) -> Box<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures_util::FutureExt;
-    use futures_util::StreamExt;
     use std::thread;
 
     #[test]


### PR DESCRIPTION
…from here

Re-exporting makes it easier for people to mix futures 0.2 and futures
0.1/0.3 in the same application as inside Cargo.toml only one can be
specified. This allows to use e.g. tokio and GLib futures easily in the
same application.

CC @alatiera