### PR TITLE
Make ObjectType::new() optional too

### DIFF
--- a/src/subclass/types.rs
+++ b/src/subclass/types.rs
@@ -313,7 +313,11 @@ pub trait ObjectSubclass: ObjectImpl + Sized + 'static {
     /// This is called during object instantiation before further subclasses
     /// are initialized, and should return a new instance of the subclass
     /// private struct.
-    fn new() -> Self;
+    ///
+    /// Optional, either implement this or `new_with_class()`.
+    fn new() -> Self {
+        unimplemented!();
+    }
 
     /// Constructor.
     ///
@@ -324,7 +328,7 @@ pub trait ObjectSubclass: ObjectImpl + Sized + 'static {
     /// Different to `new()` above it also gets the class of this type passed
     /// to itself for providing additional context.
     ///
-    /// Optional, calls `new()` by default.
+    /// Optional, either implement this or `new()`.
     fn new_with_class(_klass: &Self::Class) -> Self {
         Self::new()
     }


### PR DESCRIPTION
We either require new() or new_with_type() to be implemented. Making it
mandatory to implement new() in any case causes ugly code in subclasses
that only want to implement new_with_type().

----

This has the negative side-effect that there's no compiler warning if neither is implemented... but users will notice very fast because their code just does not work at all due to the `unimplemented!()` default implementation.

Compared to ugly code like [this](https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/blob/fb741f26f3bef6a3ae84549a69a477273cbd8454/gst-plugin-tutorial/src/identity.rs#L165-173) I really prefer that.