### PR TITLE
BoolError: allow owning the message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,8 @@ pub mod boxed;
 #[macro_use]
 pub mod shared;
 #[macro_use]
+pub mod error;
+#[macro_use]
 pub mod object;
 
 pub use auto::*;
@@ -174,7 +176,6 @@ pub mod char;
 pub use char::*;
 mod checksum;
 pub mod closure;
-pub mod error;
 mod enums;
 mod file_error;
 mod key_file;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -56,10 +56,14 @@ pub fn setenv<K: AsRef<OsStr>, V: AsRef<OsStr>>(variable_name: K, value: V, over
     use ffi::g_setenv;
 
     unsafe {
-        BoolError::from_glib(g_setenv(variable_name.as_ref().to_glib_none().0,
-                                value.as_ref().to_glib_none().0,
-                                overwrite.to_glib()),
-                             "Failed to set environment variable")
+        glib_result_from_gboolean!(
+            g_setenv(
+                variable_name.as_ref().to_glib_none().0,
+                value.as_ref().to_glib_none().0,
+                overwrite.to_glib(),
+            ),
+            "Failed to set environment variable"
+        )
     }
 }
 


### PR DESCRIPTION
`BoolError` can currently only be built from a `&'static str`.
This prevents the user from dynamically building the message.

Thanks to @sdroege for [suggesting to use `Cow`](https://gitlab.freedesktop.org/gstreamer/gstreamer-rs/merge_requests/196#note_98010).

It's also an opportunity to keep track of the location where the error was built.

This causes breaking changes in some callers but I think previous implementation was not future-proof, so the change should be done IMHO.