### PR TITLE
Clean up glib_wrapper! macro and IsA<_>, Wrapper traits and their impls

### DIFF
--- a/src/gobject/auto/binding.rs
+++ b/src/gobject/auto/binding.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use translate::*;
 
 glib_wrapper! {
-    pub struct Binding(Object<ffi::GBinding>);
+    pub struct Binding(Object<ffi::GBinding, BindingClass>);
 
     match fn {
         get_type => || ffi::g_binding_get_type(),

--- a/src/gobject/auto/mod.rs
+++ b/src/gobject/auto/mod.rs
@@ -3,7 +3,7 @@
 // DO NOT EDIT
 
 mod binding;
-pub use self::binding::Binding;
+pub use self::binding::{Binding, BindingClass};
 
 mod flags;
 pub use self::flags::BindingFlags;

--- a/src/object.rs
+++ b/src/object.rs
@@ -339,7 +339,7 @@ glib_wrapper! {
 /// ObjectType implementations for Object types. See `glib_wrapper!`.
 #[macro_export]
 macro_rules! glib_object_wrapper {
-    (@generic_impl [$($attr:meta)*] $name:ident, $ffi_name:path, $ffi_class_name:path, $rust_class_name:ident, @get_type $get_type_expr:expr) => {
+    (@generic_impl [$($attr:meta)*] $name:ident, $ffi_name:path, $ffi_class_name:path, $rust_class_name:path, @get_type $get_type_expr:expr) => {
         $(#[$attr])*
         // Always derive Hash/Ord (and below impl Debug, PartialEq, Eq, PartialOrd) for object
         // types. Due to inheritance and up/downcasting we must implement these by pointer or

--- a/src/object.rs
+++ b/src/object.rs
@@ -11,6 +11,8 @@ use gobject_ffi;
 use std::mem;
 use std::ptr;
 use std::ops;
+use std::hash;
+use std::fmt;
 use std::marker::PhantomData;
 
 use Value;
@@ -25,6 +27,7 @@ use get_thread_id;
 /// Implemented by types representing `glib::Object` and subclasses of it.
 pub unsafe trait ObjectType: UnsafeFrom<ObjectRef> + Into<ObjectRef>
         + StaticType
+        + fmt::Debug + Clone + PartialEq + Eq + PartialOrd + Ord + hash::Hash
         + for<'a> ToGlibPtr<'a, *mut <Self as ObjectType>::GlibType>
         + 'static {
     /// type of the FFI Instance structure.

--- a/src/object.rs
+++ b/src/object.rs
@@ -680,6 +680,7 @@ macro_rules! glib_object_wrapper {
         #[doc(hidden)]
         impl AsRef<$super_name> for $name {
             fn as_ref(&self) -> &$super_name {
+                debug_assert!($crate::object::ObjectExt::is::<$super_name>(self));
                 unsafe {
                     ::std::mem::transmute(self)
                 }

--- a/src/object.rs
+++ b/src/object.rs
@@ -662,20 +662,16 @@ macro_rules! glib_object_wrapper {
             #[inline]
             fn to_glib_none(&'a self) -> $crate::translate::Stash<'a,
                     *mut <$super_name as $crate::object::ObjectType>::GlibType, Self> {
+                debug_assert!($crate::object::Cast::is::<$super_name>(self));
                 let stash = $crate::translate::ToGlibPtr::to_glib_none(&self.0);
-                unsafe {
-                    debug_assert!($crate::types::instance_of::<$super_name>(stash.0 as *const _));
-                }
                 $crate::translate::Stash(stash.0 as *mut _, stash.1)
             }
 
             #[inline]
             fn to_glib_full(&self)
                     -> *mut <$super_name as $crate::object::ObjectType>::GlibType {
+                debug_assert!($crate::object::Cast::is::<$super_name>(self));
                 let ptr = $crate::translate::ToGlibPtr::to_glib_full(&self.0);
-                unsafe {
-                    debug_assert!($crate::types::instance_of::<$super_name>(ptr as *const _));
-                }
                 ptr as *mut _
             }
         }
@@ -691,19 +687,15 @@ macro_rules! glib_object_wrapper {
 
             #[inline]
             fn to_glib_none(&'a self) -> $crate::translate::Stash<'a, *mut $super_ffi, Self> {
+                debug_assert!($crate::object::Cast::is::<$super_name>(self));
                 let stash = $crate::translate::ToGlibPtr::to_glib_none(&self.0);
-                unsafe {
-                    debug_assert!($crate::types::instance_of::<$super_name>(stash.0 as *const _));
-                }
                 $crate::translate::Stash(stash.0 as *mut _, stash.1)
             }
 
             #[inline]
             fn to_glib_full(&self) -> *mut $super_ffi {
+                debug_assert!($crate::object::Cast::is::<$super_name>(self));
                 let ptr = $crate::translate::ToGlibPtr::to_glib_full(&self.0);
-                unsafe {
-                    debug_assert!($crate::types::instance_of::<$super_name>(ptr as *const _));
-                }
                 ptr as *mut _
             }
         }

--- a/src/object.rs
+++ b/src/object.rs
@@ -753,13 +753,10 @@ macro_rules! glib_object_wrapper {
         glib_object_wrapper!(@class_impl $name, $ffi_class_name, $rust_class_name);
     };
 
-    (@interface [$($attr:meta)*] $name:ident, $ffi_name:path, $ffi_class_name:path, $rust_class_name:ident,
-        @get_type $get_type_expr:expr, @implements $($implements:tt)*) => {
-        glib_object_wrapper!(@generic_impl [$($attr)*] $name, $ffi_name, $ffi_class_name, $rust_class_name,
+    (@interface [$($attr:meta)*] $name:ident, $ffi_name:path, @get_type $get_type_expr:expr, @implements $($implements:tt)*) => {
+        glib_object_wrapper!(@generic_impl [$($attr)*] $name, $ffi_name, $crate::wrapper::Void, $crate::wrapper::Void,
             @get_type $get_type_expr);
         glib_object_wrapper!(@munch_impls $name, $($implements)*);
-
-        // We don't do anything with the $ffi_class_name and $rust_class_name for now
     };
 }
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -290,7 +290,7 @@ pub trait Cast: IsA<Object> {
     unsafe fn unsafe_cast<T>(self) -> T
       where T: StaticType + UnsafeFrom<ObjectRef> + Wrapper {
         debug_assert!(self.is::<T>());
-        T::from(self.into())
+        T::unsafe_from(self.into())
     }
 
     /// Casts to `&T` unconditionally.
@@ -352,7 +352,7 @@ macro_rules! glib_object_wrapper {
 
         #[doc(hidden)]
         impl $crate::wrapper::UnsafeFrom<$crate::object::ObjectRef> for $name {
-            unsafe fn from(t: $crate::object::ObjectRef) -> Self {
+            unsafe fn unsafe_from(t: $crate::object::ObjectRef) -> Self {
                 $name(t, ::std::marker::PhantomData)
             }
         }
@@ -1215,7 +1215,7 @@ impl<T: IsA<Object>> WeakRef<T> {
                 None
             } else {
                 let obj: Object = from_glib_full(ptr);
-                Some(T::from(obj.into()))
+                Some(T::unsafe_from(obj.into()))
             }
         }
     }

--- a/src/object.rs
+++ b/src/object.rs
@@ -59,8 +59,7 @@ pub trait UnsafeFrom<T> {
 /// implementations exist.
 ///
 /// `T` always implements `IsA<T>`.
-pub unsafe trait IsA<T: ObjectType>: ObjectType + AsRef<T> +
-    for<'a> ToGlibPtr<'a, *mut <T as ObjectType>::GlibType> + 'static { }
+pub unsafe trait IsA<T: ObjectType>: ObjectType + AsRef<T> + 'static { }
 
 unsafe impl<T: ObjectType + AsRef<T>> IsA<T> for T {}
 
@@ -676,29 +675,6 @@ macro_rules! glib_object_wrapper {
     (@munch_impls $name:ident, ) => { };
 
     (@munch_impls $name:ident, $super_name:path) => {
-        #[doc(hidden)]
-        impl<'a> $crate::translate::ToGlibPtr<'a,
-                *mut <$super_name as $crate::object::ObjectType>::GlibType> for $name {
-            type Storage = <$crate::object::ObjectRef as
-                $crate::translate::ToGlibPtr<'a, *mut $crate::object::GObject>>::Storage;
-
-            #[inline]
-            fn to_glib_none(&'a self) -> $crate::translate::Stash<'a,
-                    *mut <$super_name as $crate::object::ObjectType>::GlibType, Self> {
-                debug_assert!($crate::object::Cast::is::<$super_name>(self));
-                let stash = $crate::translate::ToGlibPtr::to_glib_none(&self.0);
-                $crate::translate::Stash(stash.0 as *mut _, stash.1)
-            }
-
-            #[inline]
-            fn to_glib_full(&self)
-                    -> *mut <$super_name as $crate::object::ObjectType>::GlibType {
-                debug_assert!($crate::object::Cast::is::<$super_name>(self));
-                let ptr = $crate::translate::ToGlibPtr::to_glib_full(&self.0);
-                ptr as *mut _
-            }
-        }
-
         unsafe impl $crate::object::IsA<$super_name> for $name { }
 
         #[doc(hidden)]
@@ -712,26 +688,6 @@ macro_rules! glib_object_wrapper {
     };
 
     (@munch_impls $name:ident, $super_name:path => $super_ffi:path) => {
-        #[doc(hidden)]
-        impl<'a> $crate::translate::ToGlibPtr<'a, *mut $super_ffi> for $name {
-            type Storage = <$crate::object::ObjectRef as
-                $crate::translate::ToGlibPtr<'a, *mut $crate::object::GObject>>::Storage;
-
-            #[inline]
-            fn to_glib_none(&'a self) -> $crate::translate::Stash<'a, *mut $super_ffi, Self> {
-                debug_assert!($crate::object::Cast::is::<$super_name>(self));
-                let stash = $crate::translate::ToGlibPtr::to_glib_none(&self.0);
-                $crate::translate::Stash(stash.0 as *mut _, stash.1)
-            }
-
-            #[inline]
-            fn to_glib_full(&self) -> *mut $super_ffi {
-                debug_assert!($crate::object::Cast::is::<$super_name>(self));
-                let ptr = $crate::translate::ToGlibPtr::to_glib_full(&self.0);
-                ptr as *mut _
-            }
-        }
-
         unsafe impl $crate::object::IsA<$super_name> for $name { }
 
         #[doc(hidden)]
@@ -759,24 +715,6 @@ macro_rules! glib_object_wrapper {
         glib_object_wrapper!([$($attr)*] $name, $ffi_name, $ffi_class_name, $rust_class_name,
             @get_type $get_type_expr);
         glib_object_wrapper!(@munch_impls $name, $($implements)*);
-
-        #[doc(hidden)]
-        impl<'a> $crate::translate::ToGlibPtr<'a, *mut $crate::object::GObject> for $name {
-            type Storage = <$crate::object::ObjectRef as
-                $crate::translate::ToGlibPtr<'a, *mut $crate::object::GObject>>::Storage;
-
-            #[inline]
-            fn to_glib_none(&'a self)
-                    -> $crate::translate::Stash<'a, *mut $crate::object::GObject, Self> {
-                let stash = $crate::translate::ToGlibPtr::to_glib_none(&self.0);
-                $crate::translate::Stash(stash.0 as *mut _, stash.1)
-            }
-
-            #[inline]
-            fn to_glib_full(&self) -> *mut $crate::object::GObject {
-                $crate::translate::ToGlibPtr::to_glib_full(&self.0) as *mut _
-            }
-        }
 
         unsafe impl $crate::object::IsA<$crate::object::Object> for $name { }
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -687,31 +687,13 @@ macro_rules! glib_object_wrapper {
         }
     };
 
-    (@munch_impls $name:ident, $super_name:path => $super_ffi:path) => {
-        unsafe impl $crate::object::IsA<$super_name> for $name { }
-
-        #[doc(hidden)]
-        impl AsRef<$super_name> for $name {
-            fn as_ref(&self) -> &$super_name {
-                unsafe {
-                    ::std::mem::transmute(self)
-                }
-            }
-        }
-    };
-
-    (@munch_impls $name:ident, $super_name:path, $($implements:tt)*) => {
+    (@munch_impls $name:ident, $super_name:path, $($implements:path)*) => {
         glib_object_wrapper!(@munch_impls $name, $super_name);
         glib_object_wrapper!(@munch_impls $name, $($implements)*);
     };
 
-    (@munch_impls $name:ident, $super_name:path => $super_ffi:path, $($implements:tt)*) => {
-        glib_object_wrapper!(@munch_impls $name, $super_name => $super_ffi);
-        glib_object_wrapper!(@munch_impls $name, $($implements)*);
-    };
-
     ([$($attr:meta)*] $name:ident, $ffi_name:path, $ffi_class_name:path, $rust_class_name:path,
-        @get_type $get_type_expr:expr, @implements $($implements:tt)*) => {
+        @get_type $get_type_expr:expr, @implements $($implements:path)*) => {
         glib_object_wrapper!([$($attr)*] $name, $ffi_name, $ffi_class_name, $rust_class_name,
             @get_type $get_type_expr);
         glib_object_wrapper!(@munch_impls $name, $($implements)*);
@@ -726,12 +708,6 @@ macro_rules! glib_object_wrapper {
                 }
             }
         }
-    };
-
-    ([$($attr:meta)*] $name:ident, $ffi_name:path, $ffi_class_name:path, $rust_class_name:path, @get_type $get_type_expr:expr,
-     [$($implements:path),*]) => {
-        glib_object_wrapper!([$($attr)*] $name, $ffi_name, $ffi_class_name, $rust_class_name,
-            @get_type $get_type_expr, @implements $($implements),*);
     };
 }
 

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -8,7 +8,7 @@ use libc::{c_char, c_void, c_ulong};
 
 use gobject_ffi::{self, GCallback};
 use ffi::gboolean;
-use object::{IsA, Object};
+use object::ObjectType;
 use translate::{from_glib, FromGlib, ToGlib, ToGlibPtr};
 
 /// The id of a signal that is returned by `connect`.
@@ -61,28 +61,28 @@ pub unsafe fn connect_raw(receiver: *mut gobject_ffi::GObject, signal_name: *con
     from_glib(handle)
 }
 
-pub fn signal_handler_block<T: IsA<Object>>(instance: &T, handler_id: &SignalHandlerId) {
+pub fn signal_handler_block<T: ObjectType>(instance: &T, handler_id: &SignalHandlerId) {
     unsafe {
-        gobject_ffi::g_signal_handler_block(instance.to_glib_none().0, handler_id.to_glib());
+        gobject_ffi::g_signal_handler_block(instance.as_object_ref().to_glib_none().0, handler_id.to_glib());
     }
 }
 
-pub fn signal_handler_unblock<T: IsA<Object>>(instance: &T, handler_id: &SignalHandlerId) {
+pub fn signal_handler_unblock<T: ObjectType>(instance: &T, handler_id: &SignalHandlerId) {
     unsafe {
-        gobject_ffi::g_signal_handler_unblock(instance.to_glib_none().0, handler_id.to_glib());
+        gobject_ffi::g_signal_handler_unblock(instance.as_object_ref().to_glib_none().0, handler_id.to_glib());
     }
 }
 
 #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
-pub fn signal_handler_disconnect<T: IsA<Object>>(instance: &T, handler_id: SignalHandlerId) {
+pub fn signal_handler_disconnect<T: ObjectType>(instance: &T, handler_id: SignalHandlerId) {
     unsafe {
-        gobject_ffi::g_signal_handler_disconnect(instance.to_glib_none().0, handler_id.to_glib());
+        gobject_ffi::g_signal_handler_disconnect(instance.as_object_ref().to_glib_none().0, handler_id.to_glib());
     }
 }
 
-pub fn signal_stop_emission_by_name<T: IsA<Object>>(instance: &T, signal_name: &str) {
+pub fn signal_stop_emission_by_name<T: ObjectType>(instance: &T, signal_name: &str) {
     unsafe {
-        gobject_ffi::g_signal_stop_emission_by_name(instance.to_glib_none().0, signal_name.to_glib_none().0);
+        gobject_ffi::g_signal_stop_emission_by_name(instance.as_object_ref().to_glib_none().0, signal_name.to_glib_none().0);
     }
 }
 

--- a/src/subclass/simple.rs
+++ b/src/subclass/simple.rs
@@ -7,14 +7,14 @@
 //! structs and don't provide any new virtual methods.
 
 use super::prelude::*;
-use wrapper::Wrapper;
+use object::ObjectType;
 
 use std::ops;
 
 /// A simple instance struct that does not store any additional data.
 #[repr(C)]
 pub struct InstanceStruct<T: ObjectSubclass> {
-    parent: <T::ParentType as Wrapper>::GlibType,
+    parent: <T::ParentType as ObjectType>::GlibType,
 }
 
 unsafe impl<T: ObjectSubclass> super::types::InstanceStruct for InstanceStruct<T> {
@@ -25,7 +25,7 @@ unsafe impl<T: ObjectSubclass> super::types::InstanceStruct for InstanceStruct<T
 /// or virtual methods.
 #[repr(C)]
 pub struct ClassStruct<T: ObjectSubclass> {
-    parent_class: <T::ParentType as Wrapper>::GlibClassType,
+    parent_class: <T::ParentType as ObjectType>::GlibClassType,
 }
 
 unsafe impl<T: ObjectSubclass> super::types::ClassStruct for ClassStruct<T> {
@@ -33,7 +33,7 @@ unsafe impl<T: ObjectSubclass> super::types::ClassStruct for ClassStruct<T> {
 }
 
 impl<T: ObjectSubclass> ops::Deref for ClassStruct<T> {
-    type Target = <<T as ObjectSubclass>::ParentType as Wrapper>::RustClassType;
+    type Target = <<T as ObjectSubclass>::ParentType as ObjectType>::RustClassType;
 
     fn deref(&self) -> &Self::Target {
         unsafe { &*(self as *const _ as *const Self::Target) }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -190,35 +190,6 @@
 /// }
 /// ```
 ///
-/// #### Wrapping objects with parents/interfaces from different crates
-///
-/// Implementing types whose parents or interfaces come from different
-/// crates requires specifying the wrapped names of the
-/// parents/interfaces and their FFI counterparts as well.  Note that
-/// these must be specified inside square brackets "`[]`", as
-/// comma-delimited pairs like
-/// "`crate_name::WrappedName => ffi_crate_name::Name`".
-///
-/// Here, note that the parent class for `ffi::GtkApplication` is
-/// `gio::Application`, which is the Rust wrapper for
-/// `gio_ffi::GApplication`.  Similarly, the `ActionGroup` and
-/// `ActionMap` interfaces, and their corresponding ffi structs, come
-/// from different crates.
-///
-/// ```ignore
-/// glib_wrapper! {
-///     pub struct Application(Object<ffi::GtkApplication, ffi::GtkApplicationClass>): [
-///         gio::Application => gio_ffi::GApplication,
-///         gio::ActionGroup => gio_ffi::GActionGroup,
-///         gio::ActionMap   => gio_ffi::GActionMap,
-///     ];
-///
-///     match fn {
-///         get_type => || ffi::gtk_application_get_type(),
-///     }
-/// }
-/// ```
-///
 /// #### Non-derivable classes
 ///
 /// By convention, GObject implements "final" classes, i.e. those who
@@ -333,45 +304,6 @@ macro_rules! glib_wrapper {
         }
     ) => {
         glib_object_wrapper!([$($attr)*] $name, $ffi_name, $ffi_class_name, $rust_class_name, @get_type $get_type_expr, []);
-    };
-
-    // Object, no class struct, no rust class struct, parents in other crates
-    (
-        $(#[$attr:meta])*
-        pub struct $name:ident(Object<$ffi_name:path>): [$($implements:tt)+];
-
-        match fn {
-            get_type => || $get_type_expr:expr,
-        }
-    ) => {
-        glib_object_wrapper!([$($attr)*] $name, $ffi_name, $crate::wrapper::Void, $crate::wrapper::Void,
-            @get_type $get_type_expr, @implements $($implements)+);
-    };
-
-    // Object, class struct, no rust class struct, parents in other crates
-    (
-        $(#[$attr:meta])*
-        pub struct $name:ident(Object<$ffi_name:path, $ffi_class_name:path>): [$($implements:tt)+];
-
-        match fn {
-            get_type => || $get_type_expr:expr,
-        }
-    ) => {
-        glib_object_wrapper!([$($attr)*] $name, $ffi_name, $ffi_class_name, $crate::wrapper::Void, @get_type $get_type_expr,
-            @implements $($implements)+);
-    };
-
-    // Object, class struct, rust class struct, parents in other crates
-    (
-        $(#[$attr:meta])*
-        pub struct $name:ident(Object<$ffi_name:path, $ffi_class_name:path, $rust_class_name:path>): [$($implements:tt)+];
-
-        match fn {
-            get_type => || $get_type_expr:expr,
-        }
-    ) => {
-        glib_object_wrapper!([$($attr)*] $name, $ffi_name, $ffi_class_name, $rust_class_name, @get_type $get_type_expr,
-            @implements $($implements)+);
     };
 
     // Object, no class struct, no rust class struct, parents

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -414,19 +414,5 @@ macro_rules! glib_wrapper {
     };
 }
 
-/// Represents a pair of structures (instance, class) as exposed by descendants of GObject.
-pub trait Wrapper {
-    /// type of the FFI Instance structure.
-    type GlibType: 'static;
-    /// type of the FFI Class structure.
-    type GlibClassType: 'static;
-    /// type of the Rust Class structure.
-    type RustClassType: 'static;
-}
-
-pub trait UnsafeFrom<T> {
-    unsafe fn unsafe_from(t: T) -> Self;
-}
-
 // So we can refer to the empty type by a path
 pub type Void = ();

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -332,29 +332,28 @@ macro_rules! glib_wrapper {
             @get_type $get_type_expr, @implements $($implements),+);
     };
 
-    // Interface, class struct, no prerequisites
+    // Interface, no prerequisites
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Interface<$ffi_name:path, $ffi_class_name:path, $rust_class_name:ident>);
+        pub struct $name:ident(Interface<$ffi_name:path>);
 
         match fn {
             get_type => || $get_type_expr:expr,
         }
     ) => {
-        glib_object_wrapper!(@interface [$($attr)*] $name, $ffi_name, $ffi_class_name, $rust_class_name, @get_type $get_type_expr, @implements $crate::object::Object);
+        glib_object_wrapper!(@interface [$($attr)*] $name, $ffi_name, @get_type $get_type_expr, @implements $crate::object::Object);
     };
 
-    // Interface, class struct, prerequisites
+    // Interface, prerequisites
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Interface<$ffi_name:path, $ffi_class_name:path, $rust_class_name:ident>): $($implements:path),+;
+        pub struct $name:ident(Interface<$ffi_name:path>): $($implements:path),+;
 
         match fn {
             get_type => || $get_type_expr:expr,
         }
     ) => {
-        glib_object_wrapper!(@interface [$($attr)*] $name, $ffi_name, $ffi_class_name, $rust_class_name,
-            @get_type $get_type_expr, @implements $($implements),+);
+        glib_object_wrapper!(@interface [$($attr)*] $name, $ffi_name, @get_type $get_type_expr, @implements $($implements),+);
     };
 }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -291,7 +291,7 @@ macro_rules! glib_wrapper {
             get_type => || $get_type_expr:expr,
         }
     ) => {
-        glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, $crate::wrapper::Void, $rust_class_name, @get_type $get_type_expr, @implements $crate::object::Object);
+        glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, $crate::wrapper::Void, $rust_class_name, @get_type $get_type_expr, @implements );
     };
 
     // Object, class struct, no parents
@@ -303,7 +303,7 @@ macro_rules! glib_wrapper {
             get_type => || $get_type_expr:expr,
         }
     ) => {
-        glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, $ffi_class_name, $rust_class_name, @get_type $get_type_expr, @implements $crate::object::Object);
+        glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, $ffi_class_name, $rust_class_name, @get_type $get_type_expr, @implements );
     };
 
     // Object, no class struct, parents
@@ -341,7 +341,7 @@ macro_rules! glib_wrapper {
             get_type => || $get_type_expr:expr,
         }
     ) => {
-        glib_object_wrapper!(@interface [$($attr)*] $name, $ffi_name, @get_type $get_type_expr, @implements $crate::object::Object);
+        glib_object_wrapper!(@interface [$($attr)*] $name, $ffi_name, @get_type $get_type_expr, @implements );
     };
 
     // Interface, prerequisites

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -425,7 +425,7 @@ pub trait Wrapper {
 }
 
 pub trait UnsafeFrom<T> {
-    unsafe fn from(t: T) -> Self;
+    unsafe fn unsafe_from(t: T) -> Self;
 }
 
 // So we can refer to the empty type by a path


### PR DESCRIPTION
This PR is still WIP as it also requires a corresponding [PR for gir](https://github.com/gtk-rs/gir/pull/689). The changes are
* Rename `Wrapper` trait to `ObjectType` to be more descriptive and add more useful API around it
* `glib_wrapper!` does not need FFI types for the parent classes in other crates anymore
* `Downcast` trait became `CanDowncast`, and the `Cast` trait impl was cleaned up
* Generate Rust class structs for class types in `glib_wrapper!`, and distinguish between classes and interfaces
* `IsA<_>` is cleaned up and does not require `ToGlibPtr` impls for everything anymore (that's why FFI types were needed). Instead `IsA<T>` requires `AsRef<T>`, i.e. we can always get back to a `&T` which then has all the traits we care about implemented.
* `IsA<Object>` and `ObjectType` (former `Wrapper`) trait bounds are equivalent, i.e. `IsA<Object>` is implemented for every `ObjectType`. They can be used interchangeably.