### PR TITLE
Add new Object::connect_unsafe(), Object::connect_notify_unsafe() and…

### DIFF
--- a/src/closure.rs
+++ b/src/closure.rs
@@ -32,10 +32,16 @@ glib_wrapper! {
 
 impl Closure {
     pub fn new<F: Fn(&[Value]) -> Option<Value> + Send + Sync + 'static>(callback: F) -> Self {
+        unsafe {
+            Closure::new_unsafe(callback)
+        }
+    }
+
+    pub unsafe fn new_unsafe<F: Fn(&[Value]) -> Option<Value>>(callback: F) -> Self {
         unsafe extern "C" fn marshal<F>(_closure: *mut gobject_ffi::GClosure, return_value: *mut gobject_ffi::GValue,
             n_param_values: c_uint, param_values: *mut gobject_ffi::GValue, _invocation_hint: *mut c_void,
             marshal_data: *mut c_void)
-            where F: Fn(&[Value]) -> Option<Value> + Send + Sync + 'static
+            where F: Fn(&[Value]) -> Option<Value>
         {
             let values = slice::from_raw_parts(param_values as *const _, n_param_values as usize);
             let callback: Box<F> = Box::from_raw(marshal_data as *mut _);
@@ -53,23 +59,27 @@ impl Closure {
         }
 
         unsafe extern "C" fn finalize<F>(notify_data: *mut c_void, _closure: *mut gobject_ffi::GClosure)
-            where F: Fn(&[Value]) -> Option<Value> + Send + Sync + 'static
+            where F: Fn(&[Value]) -> Option<Value>
         {
             let _callback: Box<F> = Box::from_raw(notify_data as *mut _);
             // callback is dropped here.
         }
 
-        unsafe {
-            let size = 4 + 4 + 3 * mem::size_of::<*mut c_void>() as u32;
-            let closure = gobject_ffi::g_closure_new_simple(size, ptr::null_mut());
-            assert_ne!(closure, ptr::null_mut());
-            let callback = Box::new(callback);
-            let ptr: *mut F = Box::into_raw(callback);
-            let ptr: *mut c_void = ptr as *mut _;
-            gobject_ffi::g_closure_set_meta_marshal(closure, ptr, Some(marshal::<F>));
-            gobject_ffi::g_closure_add_finalize_notifier(closure, ptr, Some(finalize::<F>));
-            from_glib_none(closure)
-        }
+        // Due to bitfields we have to do our own calculations here for the size of the GClosure:
+        // - 4: 32 bits in guint bitfields at the beginning
+        // - padding due to alignment needed for the following pointer
+        // - 3 * size_of<*mut c_void>: 3 pointers
+        // We don't store any custom data ourselves in the GClosure
+        let size = u32::max(4, mem::align_of::<*mut c_void>() as u32)
+            + 3 * mem::size_of::<*mut c_void>() as u32;
+        let closure = gobject_ffi::g_closure_new_simple(size, ptr::null_mut());
+        assert_ne!(closure, ptr::null_mut());
+        let callback = Box::new(callback);
+        let ptr: *mut F = Box::into_raw(callback);
+        let ptr: *mut c_void = ptr as *mut _;
+        gobject_ffi::g_closure_set_meta_marshal(closure, ptr, Some(marshal::<F>));
+        gobject_ffi::g_closure_add_finalize_notifier(closure, ptr, Some(finalize::<F>));
+        from_glib_none(closure)
     }
 
     pub fn invoke(&self, values: &[&ToValue]) -> Option<Value> {


### PR DESCRIPTION
… Closure::new_unsafe()

These allow to use non-Send/non-Sync closures and it's the job of the
caller to ensure that the closures are only used in a safe way.