### PR TITLE
For setting properties and the return value of signal handlers relax …

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -103,7 +103,7 @@ use gobject_ffi;
 /// See the [module documentation](index.html) for more details.
 // TODO: Should use impl !Send for Value {} once stable
 #[repr(C)]
-pub struct Value(gobject_ffi::GValue, PhantomData<*const c_void>);
+pub struct Value(pub(crate) gobject_ffi::GValue, PhantomData<*const c_void>);
 
 impl Value {
     /// Creates a new `Value` that is initialized with `type_`


### PR DESCRIPTION
…the type checks

Instead of requiring that the type of the Value itself has to be
compatible, we are checking for Object subclasses also if the type of
the contained object is compatible and if it is make sure that
everything works correctly.

This can happen for example if a button is stored in a gtk::Widget typed
variable and then converted to a glib::Value. The Value will have the
type of Widget and not Button, and type checks would fail.