### PR TITLE
Don't use deprecated ATOMIC_USIZE_INIT

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,9 +226,9 @@ pub use source_futures::*;
 // This works around it by using our own counter for threads.
 //
 // Taken from the fragile crate
-use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use std::sync::atomic::{AtomicUsize, Ordering};
 fn next_thread_id() -> usize {
-    static mut COUNTER: AtomicUsize = ATOMIC_USIZE_INIT;
+    static mut COUNTER: AtomicUsize = AtomicUsize::new(0);
     unsafe { COUNTER.fetch_add(1, Ordering::SeqCst) }
 }
 


### PR DESCRIPTION
cc @sdroege