### PR TITLE
Always ref-sink after g_object_new() if the type inherits from GIniti…

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -882,7 +882,7 @@ impl Object {
             let ptr = gobject_sys::g_object_newv(type_.to_glib(), params_c.len() as u32, mut_override(params_c.as_ptr()));
             if ptr.is_null() {
                 Err(glib_bool_error!("Can't instantiate object"))
-            } else if gobject_sys::g_object_is_floating(ptr) != glib_sys::GFALSE {
+            } else if type_.is_a(&InitiallyUnowned::static_type()) {
                 Ok(from_glib_none(ptr))
             } else {
                 Ok(from_glib_full(ptr))


### PR DESCRIPTION
…allyUnowned

Independent of it still being actually floating or not.

Fixes https://github.com/gtk-rs/glib/issues/483