### PR TITLE
Adds Copy and Clone traits to glib::SignalHandlerId.

### DIFF
--- a/src/signal.rs
+++ b/src/signal.rs
@@ -12,7 +12,7 @@ use std::mem;
 use translate::{from_glib, FromGlib, ToGlib, ToGlibPtr};
 
 /// The id of a signal that is returned by `connect`.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SignalHandlerId(c_ulong);
 
 impl ToGlib for SignalHandlerId {


### PR DESCRIPTION
I think SignalHandlerId should derive Copy and Clone, since it's just a scalar. 