### PR TITLE
subclass: panic with error message when registering existing type

### DIFF
--- a/src/subclass/boxed.rs
+++ b/src/subclass/boxed.rs
@@ -45,10 +45,9 @@ pub fn register_boxed_type<T: BoxedType>() -> ::Type {
         use std::ffi::CString;
 
         let type_name = CString::new(T::NAME).unwrap();
-        assert_eq!(
-            gobject_sys::g_type_from_name(type_name.as_ptr()),
-            gobject_sys::G_TYPE_INVALID
-        );
+        if gobject_sys::g_type_from_name(type_name.as_ptr()) != gobject_sys::G_TYPE_INVALID {
+            panic!("Type {} has already been registered", type_name.to_str().unwrap());
+        }
 
         from_glib(gobject_sys::g_boxed_type_register_static(
             type_name.as_ptr(),

--- a/src/subclass/types.rs
+++ b/src/subclass/types.rs
@@ -469,10 +469,9 @@ where
         };
 
         let type_name = CString::new(T::NAME).unwrap();
-        assert_eq!(
-            gobject_sys::g_type_from_name(type_name.as_ptr()),
-            gobject_sys::G_TYPE_INVALID
-        );
+        if gobject_sys::g_type_from_name(type_name.as_ptr()) != gobject_sys::G_TYPE_INVALID {
+            panic!("Type {} has already been registered", type_name.to_str().unwrap());
+        }
 
         let type_ = from_glib(gobject_sys::g_type_register_static(
             <T::ParentType as StaticType>::static_type().to_glib(),


### PR DESCRIPTION
The assertion wasn't very user friendly, it deserves some explanations.