### PR TITLE
Manually implement Clone for Sender/SyncSender

### DIFF
--- a/src/main_context_channel.rs
+++ b/src/main_context_channel.rs
@@ -321,8 +321,14 @@ unsafe extern "C" fn finalize<T, F: FnMut(T) -> Continue + 'static>(
 /// See [`MainContext::channel()`] for how to create such a `Sender`.
 ///
 /// [`MainContext::channel()`]: struct.MainContext.html#method.channel
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Sender<T>(Option<Channel<T>>);
+
+impl<T> Clone for Sender<T> {
+    fn clone(&self) -> Sender<T> {
+        Sender(self.0.clone())
+    }
+}
 
 impl<T> Sender<T> {
     /// Sends a value to the channel.
@@ -363,8 +369,14 @@ impl<T> Drop for Sender<T> {
 /// See [`MainContext::sync_channel()`] for how to create such a `SyncSender`.
 ///
 /// [`MainContext::sync_channel()`]: struct.MainContext.html#method.sync_channel
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct SyncSender<T>(Option<Channel<T>>);
+
+impl<T> Clone for SyncSender<T> {
+    fn clone(&self) -> SyncSender<T> {
+        SyncSender(self.0.clone())
+    }
+}
 
 impl<T> SyncSender<T> {
     /// Sends a value to the channel and blocks if the channel is full.

--- a/src/main_context_channel.rs
+++ b/src/main_context_channel.rs
@@ -6,6 +6,7 @@ use get_thread_id;
 use glib_sys;
 use std::cell::RefCell;
 use std::collections::VecDeque;
+use std::fmt;
 use std::mem;
 use std::ptr;
 use std::sync::mpsc;
@@ -17,7 +18,6 @@ use Priority;
 use Source;
 use SourceId;
 
-#[derive(Debug)]
 enum ChannelSourceState {
     NotAttached,
     Attached(*mut glib_sys::GSource),
@@ -27,7 +27,6 @@ enum ChannelSourceState {
 unsafe impl Send for ChannelSourceState {}
 unsafe impl Sync for ChannelSourceState {}
 
-#[derive(Debug)]
 struct ChannelInner<T> {
     queue: VecDeque<T>,
     source: ChannelSourceState,
@@ -71,13 +70,11 @@ impl<T> ChannelInner<T> {
     }
 }
 
-#[derive(Debug)]
 struct ChannelBound {
     bound: usize,
     cond: Condvar,
 }
 
-#[derive(Debug)]
 struct Channel<T>(Arc<(Mutex<ChannelInner<T>>, Option<ChannelBound>)>);
 
 impl<T> Clone for Channel<T> {
@@ -321,8 +318,13 @@ unsafe extern "C" fn finalize<T, F: FnMut(T) -> Continue + 'static>(
 /// See [`MainContext::channel()`] for how to create such a `Sender`.
 ///
 /// [`MainContext::channel()`]: struct.MainContext.html#method.channel
-#[derive(Debug)]
 pub struct Sender<T>(Option<Channel<T>>);
+
+impl<T> fmt::Debug for Sender<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Sender").finish()
+    }
+}
 
 impl<T> Clone for Sender<T> {
     fn clone(&self) -> Sender<T> {
@@ -369,8 +371,13 @@ impl<T> Drop for Sender<T> {
 /// See [`MainContext::sync_channel()`] for how to create such a `SyncSender`.
 ///
 /// [`MainContext::sync_channel()`]: struct.MainContext.html#method.sync_channel
-#[derive(Debug)]
 pub struct SyncSender<T>(Option<Channel<T>>);
+
+impl<T> fmt::Debug for SyncSender<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("SyncSender").finish()
+    }
+}
 
 impl<T> Clone for SyncSender<T> {
     fn clone(&self) -> SyncSender<T> {
@@ -423,8 +430,13 @@ impl<T> Drop for SyncSender<T> {
 ///
 /// [`MainContext::channel()`]: struct.MainContext.html#method.channel
 /// [`MainContext::sync_channel()`]: struct.MainContext.html#method.sync_channel
-#[derive(Debug)]
 pub struct Receiver<T>(Option<Channel<T>>, Priority);
+
+impl<T> fmt::Debug for Receiver<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Receiver").finish()
+    }
+}
 
 // It's safe to send the Receiver to other threads for attaching it as
 // long as the items to be sent can also be sent between threads.

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -138,8 +138,11 @@ unsafe impl Sync for Variant { }
 
 impl fmt::Debug for Variant {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_fmt(format_args!("Variant {{ ptr: {:?}, type: \"{}\", value: {} }}",
-            self.to_glib_none().0, self.type_(), self))
+        f.debug_struct("Variant")
+            .field("ptr", &self.to_glib_none().0)
+            .field("type", &self.type_())
+            .field("value", &self.to_string())
+            .finish()
     }
 }
 


### PR DESCRIPTION
The automatically derived implementation will only work if the channel's
item type is also implementing Clone, which is not required here.

Fixes https://github.com/gtk-rs/glib/issues/494