### PR TITLE
Implement futures-0.3 `Spawn` for `&MainContext`

### DIFF
--- a/src/main_context_futures.rs
+++ b/src/main_context_futures.rs
@@ -336,6 +336,16 @@ impl MainContext {
 
 impl Spawn for MainContext {
     fn spawn_obj(&mut self, f: FutureObj<'static, ()>) -> Result<(), SpawnError> {
+        (&*self).spawn_obj(f)
+    }
+}
+
+/// Implementing `Spawn` for a _reference_ of `MainContext` allows to convert it to a futures-0.1 `Executor`,
+/// using the futures-0.1 compatibility layer.
+///
+/// See https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/src/futures_util/compat/executor.rs.html#85
+impl Spawn for &MainContext {
+    fn spawn_obj(&mut self, f: FutureObj<'static, ()>) -> Result<(), SpawnError> {
         let source = TaskSource::new(::PRIORITY_DEFAULT, None, f);
         source.attach(Some(&*self));
         Ok(())


### PR DESCRIPTION
I'm trying to use the `MainContext` as a futures-0.1 `Executor` with the help of the futures-0.1 [compatibility layer](https://rust-lang-nursery.github.io/futures-rs/blog/2019/04/18/compatibility-layer.html).

It seems that the futures-0.3 `Spawn` needs to be implemented for a _reference_, so that's what I did (see [`0.3.0-alpha.16: futures-util/src/compat/executor.rs`](https://github.com/rust-lang-nursery/futures-rs/blob/0.3.0-alpha.16/futures-util/src/compat/executor.rs#L85)).

I can confirm that with this change I can use the main-context as a futures-0.1 executor by calling [`futures::task::SpawnExt.compat()`](https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures/task/trait.SpawnExt.html#method.compat) on it.

Does this make sense?