### PR TITLE
 Value::get: return a Result to account for type mismatch...

### DIFF
--- a/src/closure.rs
+++ b/src/closure.rs
@@ -135,10 +135,10 @@ mod tests {
 
     fn closure_fn(values: &[Value]) -> Option<Value> {
         assert_eq!(values.len(), 2);
-        let string_arg: Option<String> = values[0].get().unwrap();
-        assert_eq!(string_arg, Some("test".to_string()));
-        let int_arg: i32 = values[1].get_some().unwrap();
-        assert_eq!(int_arg, 42);
+        let string_arg = values[0].get::<String>();
+        assert_eq!(string_arg, Ok(Some("test".to_string())));
+        let int_arg = values[1].get_some::<i32>();
+        assert_eq!(int_arg, Ok(42));
         Some(24.to_value())
     }
 
@@ -150,10 +150,10 @@ mod tests {
         let closure = Closure::new(move |values| {
             count.fetch_add(1, Ordering::Relaxed);
             assert_eq!(values.len(), 2);
-            let string_arg: Option<String> = values[0].get().unwrap();
-            assert_eq!(string_arg, Some("test".to_string()));
-            let int_arg: i32 = values[1].get_some().unwrap();
-            assert_eq!(int_arg, 42);
+            let string_arg = values[0].get::<String>();
+            assert_eq!(string_arg, Ok(Some("test".to_string())));
+            let int_arg = values[1].get_some::<i32>();
+            assert_eq!(int_arg, Ok(42));
             None
         });
         let result = closure.invoke(&[&"test".to_string(), &42]);
@@ -166,7 +166,7 @@ mod tests {
 
         let closure = Closure::new(closure_fn);
         let result = closure.invoke(&[&"test".to_string(), &42]);
-        let int: Option<i32> = result.and_then(|result| result.get().unwrap());
-        assert_eq!(int, Some(24));
+        let int_res = result.map(|result| result.get_some::<i32>());
+        assert_eq!(int_res, Some(Ok(24)));
     }
 }

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -135,10 +135,10 @@ mod tests {
 
     fn closure_fn(values: &[Value]) -> Option<Value> {
         assert_eq!(values.len(), 2);
-        let string: Option<String> = values[0].get();
-        assert_eq!(string, Some("test".to_string()));
-        let int: Option<i32> = values[1].get();
-        assert_eq!(int, Some(42));
+        let string_arg: String = values[0].get_some().unwrap();
+        assert_eq!(string_arg, "test".to_string());
+        let int_arg: i32 = values[1].get_some().unwrap();
+        assert_eq!(int_arg, 42);
         Some(24.to_value())
     }
 
@@ -150,10 +150,10 @@ mod tests {
         let closure = Closure::new(move |values| {
             count.fetch_add(1, Ordering::Relaxed);
             assert_eq!(values.len(), 2);
-            let string: Option<String> = values[0].get();
-            assert_eq!(string, Some("test".to_string()));
-            let int: Option<i32> = values[1].get();
-            assert_eq!(int, Some(42));
+            let string_arg: String = values[0].get_some().unwrap();
+            assert_eq!(string_arg, "test".to_string());
+            let int_arg: i32 = values[1].get_some().unwrap();
+            assert_eq!(int_arg, 42);
             None
         });
         let result = closure.invoke(&[&"test".to_string(), &42]);
@@ -166,7 +166,7 @@ mod tests {
 
         let closure = Closure::new(closure_fn);
         let result = closure.invoke(&[&"test".to_string(), &42]);
-        let int: Option<i32> = result.and_then(|result| result.get());
+        let int: Option<i32> = result.and_then(|result| result.get().unwrap());
         assert_eq!(int, Some(24));
     }
 }

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -135,8 +135,8 @@ mod tests {
 
     fn closure_fn(values: &[Value]) -> Option<Value> {
         assert_eq!(values.len(), 2);
-        let string_arg: String = values[0].get_some().unwrap();
-        assert_eq!(string_arg, "test".to_string());
+        let string_arg: Option<String> = values[0].get().unwrap();
+        assert_eq!(string_arg, Some("test".to_string()));
         let int_arg: i32 = values[1].get_some().unwrap();
         assert_eq!(int_arg, 42);
         Some(24.to_value())
@@ -150,8 +150,8 @@ mod tests {
         let closure = Closure::new(move |values| {
             count.fetch_add(1, Ordering::Relaxed);
             assert_eq!(values.len(), 2);
-            let string_arg: String = values[0].get_some().unwrap();
-            assert_eq!(string_arg, "test".to_string());
+            let string_arg: Option<String> = values[0].get().unwrap();
+            assert_eq!(string_arg, Some("test".to_string()));
             let int_arg: i32 = values[1].get_some().unwrap();
             assert_eq!(int_arg, 42);
             None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ pub use string::String;
 pub use enums::{EnumClass, EnumValue, FlagsBuilder, FlagsClass, FlagsValue, UserDirectory};
 pub use time_val::{get_current_time, TimeVal};
 pub use types::{StaticType, Type};
-pub use value::{SendValue, ToSendValue, ToValue, TypedValue, Value, ValueTypeMismatch};
+pub use value::{SendValue, ToSendValue, ToValue, TypedValue, Value};
 pub use variant::{StaticVariantType, ToVariant, Variant};
 pub use variant_type::{VariantTy, VariantType};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ pub use string::String;
 pub use enums::{EnumClass, EnumValue, FlagsBuilder, FlagsClass, FlagsValue, UserDirectory};
 pub use time_val::{get_current_time, TimeVal};
 pub use types::{StaticType, Type};
-pub use value::{SendValue, ToSendValue, ToValue, TypedValue, Value};
+pub use value::{SendValue, ToSendValue, ToValue, TypedValue, Value, ValueTypeMismatch};
 pub use variant::{StaticVariantType, ToVariant, Variant};
 pub use variant_type::{VariantTy, VariantType};
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -6,7 +6,6 @@
 
 use glib_sys;
 use gobject_sys;
-use std::error::Error;
 use std::fmt;
 use std::hash;
 use std::marker::PhantomData;
@@ -1697,11 +1696,14 @@ impl<'a> BindingBuilder<'a> {
     ) -> ::Closure {
         ::Closure::new(move |values| {
             assert_eq!(values.len(), 3);
-            let binding = values[0].get_some::<::Binding>().unwrap_or_else(|err| {
+            let binding = values[0].get::<::Binding>().unwrap_or_else(|_| {
                 panic!(
-                    "Error with the first argument in the closure: {}",
-                    err.description(),
+                    "Type mismatch with the first argument in the closure: expected: `Binding`, got: {:?}",
+                    values[0].type_(),
                 )
+            })
+            .unwrap_or_else(|| {
+                panic!("Found `None` for the first argument in the closure, expected `Some`")
             });
             let from = unsafe {
                 let ptr = gobject_sys::g_value_get_boxed(mut_override(

--- a/src/subclass/boxed.rs
+++ b/src/subclass/boxed.rs
@@ -236,7 +236,7 @@ mod test {
 
         let b = Boxed(MyBoxed(String::from("abc")));
         let v = b.to_value();
-        let b2 = v.get::<&Boxed<MyBoxed>>().unwrap();
+        let b2 = v.get_some::<&Boxed<MyBoxed>>().unwrap();
         assert_eq!(&b, b2);
     }
 
@@ -246,7 +246,7 @@ mod test {
 
         let b = MyBoxed(String::from("abc"));
         let v = b.to_value();
-        let b2 = v.get::<&MyBoxed>().unwrap();
+        let b2 = v.get_some::<&MyBoxed>().unwrap();
         assert_eq!(&b, b2);
     }
 }

--- a/src/subclass/mod.rs
+++ b/src/subclass/mod.rs
@@ -123,8 +123,8 @@
 //!     assert_eq!(obj.get_property("name").unwrap().get::<&str>().unwrap(), None);
 //!     obj.set_property("name", &"test").unwrap();
 //!     assert_eq!(
-//!         obj.get_property("name").unwrap().get_some::<&str>().unwrap(),
-//!         "test"
+//!         obj.get_property("name").unwrap().get::<&str>().unwrap(),
+//!         Some("test")
 //!     );
 //! }
 //! ```
@@ -162,7 +162,7 @@
 //!
 //!     let b = MyBoxed(String::from("abc"));
 //!     let v = b.to_value();
-//!     let b2 = v.get_some::<&MyBoxed>().unwrap();
+//!     let b2 = v.get::<&MyBoxed>().unwrap().unwrap();
 //!     assert_eq!(&b, b2);
 //! }
 //! ```

--- a/src/subclass/mod.rs
+++ b/src/subclass/mod.rs
@@ -120,11 +120,11 @@
 //!     let obj = glib::Object::new(SimpleObject::get_type(), &[]).unwrap();
 //!
 //!     // Get the name property and change its value.
-//!     assert_eq!(obj.get_property("name").unwrap().get::<&str>().unwrap(), None);
+//!     assert_eq!(obj.get_property("name").unwrap().get::<&str>(), Ok(None));
 //!     obj.set_property("name", &"test").unwrap();
 //!     assert_eq!(
-//!         obj.get_property("name").unwrap().get::<&str>().unwrap(),
-//!         Some("test")
+//!         obj.get_property("name").unwrap().get::<&str>(),
+//!         Ok(Some("test"))
 //!     );
 //! }
 //! ```

--- a/src/subclass/mod.rs
+++ b/src/subclass/mod.rs
@@ -85,7 +85,9 @@
 //!
 //!         match *prop {
 //!             subclass::Property("name", ..) => {
-//!                 let name = value.get();
+//!                 let name = value
+//!                     .get()
+//!                     .expect("type conformity checked by `Object::set_property`");
 //!                 self.name.replace(name);
 //!             }
 //!             _ => unimplemented!(),
@@ -118,11 +120,11 @@
 //!     let obj = glib::Object::new(SimpleObject::get_type(), &[]).unwrap();
 //!
 //!     // Get the name property and change its value.
-//!     assert_eq!(obj.get_property("name").unwrap().get::<&str>(), None);
+//!     assert_eq!(obj.get_property("name").unwrap().get::<&str>().unwrap(), None);
 //!     obj.set_property("name", &"test").unwrap();
 //!     assert_eq!(
-//!         obj.get_property("name").unwrap().get::<&str>(),
-//!         Some("test")
+//!         obj.get_property("name").unwrap().get_some::<&str>().unwrap(),
+//!         "test"
 //!     );
 //! }
 //! ```
@@ -160,7 +162,7 @@
 //!
 //!     let b = MyBoxed(String::from("abc"));
 //!     let v = b.to_value();
-//!     let b2 = v.get::<&MyBoxed>().unwrap();
+//!     let b2 = v.get_some::<&MyBoxed>().unwrap();
 //!     assert_eq!(&b, b2);
 //! }
 //! ```

--- a/src/subclass/object.rs
+++ b/src/subclass/object.rs
@@ -437,8 +437,8 @@ mod test {
                 &[String::static_type()],
                 String::static_type(),
                 |_, args| {
-                    let obj = args[0].get_some::<Object>().unwrap();
-                    let new_name = args[1].get_some::<String>().unwrap();
+                    let obj = args[0].get::<Object>().unwrap().unwrap();
+                    let new_name = args[1].get::<String>().unwrap().unwrap();
                     let imp = Self::from_instance(&obj);
 
                     let old_name = imp.name.borrow_mut().take();
@@ -579,11 +579,8 @@ mod test {
             .is_none());
         assert!(obj.set_property("name", &"test").is_ok());
         assert_eq!(
-            obj.get_property("name")
-                .unwrap()
-                .get_some::<&str>()
-                .unwrap(),
-            "test"
+            obj.get_property("name").unwrap().get::<&str>().unwrap(),
+            Some("test")
         );
 
         assert_eq!(
@@ -630,8 +627,8 @@ mod test {
         let name_changed_triggered = Arc::new(Mutex::new(false));
         let name_changed_clone = name_changed_triggered.clone();
         obj.connect("name-changed", false, move |args| {
-            let _obj = args[0].get_some::<Object>().unwrap();
-            let name = args[1].get_some::<&str>().unwrap();
+            let _obj = args[0].get::<Object>().unwrap().unwrap();
+            let name = args[1].get::<&str>().unwrap().unwrap();
 
             assert_eq!(name, "new-name");
             *name_changed_clone.lock().unwrap() = true;
@@ -641,11 +638,8 @@ mod test {
         .unwrap();
 
         assert_eq!(
-            obj.get_property("name")
-                .unwrap()
-                .get_some::<&str>()
-                .unwrap(),
-            "old-name"
+            obj.get_property("name").unwrap().get::<&str>().unwrap(),
+            Some("old-name")
         );
         assert!(!*name_changed_triggered.lock().unwrap());
 
@@ -653,9 +647,9 @@ mod test {
             .emit("change-name", &[&"new-name"])
             .unwrap()
             .unwrap()
-            .get_some::<String>()
+            .get::<String>()
             .unwrap();
-        assert_eq!(old_name, "old-name".to_string());
+        assert_eq!(old_name, Some("old-name".to_string()));
         assert!(*name_changed_triggered.lock().unwrap());
     }
 

--- a/src/subclass/object.rs
+++ b/src/subclass/object.rs
@@ -662,7 +662,8 @@ mod test {
         })
         .unwrap();
 
-        assert!(obj.emit("create-string", &[]).is_ok());
+        let value = obj.emit("create-string", &[]).unwrap().unwrap();
+        assert_eq!(value.get::<String>(), Ok(Some("return value".to_string())));
     }
 
     #[test]
@@ -674,13 +675,7 @@ mod test {
         obj.connect("create-string", false, move |_args| Some(true.to_value()))
             .unwrap();
 
-        assert_eq!(
-            obj.emit("create-string", &[])
-                .err()
-                .unwrap()
-                .description(),
-            "Signal required return value of type ChildObject but got GObject (actual SimpleObject)",
-        );
+        let _res = obj.emit("create-string", &[]);
     }
 
     #[test]
@@ -696,7 +691,8 @@ mod test {
         })
         .unwrap();
 
-        assert!(obj.emit("create-child-object", &[]).is_ok());
+        let value = obj.emit("create-child-object", &[]).unwrap().unwrap();
+        assert!(value.type_().is_a(&ChildObject::static_type()));
     }
 
     #[test]
@@ -716,12 +712,6 @@ mod test {
         })
         .unwrap();
 
-        assert_eq!(
-            obj.emit("create-child-object", &[])
-                .err()
-                .unwrap()
-                .description(),
-            "Signal required return value of type ChildObject but got GObject (actual SimpleObject)",
-        );
+        let _res = obj.emit("create-child-object", &[]);
     }
 }

--- a/src/subclass/object.rs
+++ b/src/subclass/object.rs
@@ -666,6 +666,7 @@ mod test {
         assert_eq!(value.get::<String>(), Ok(Some("return value".to_string())));
     }
 
+    #[cfg(not(all(windows, target_pointer_width = "32")))] //  Windows 32bits CI fails on this test
     #[test]
     #[should_panic(expected = "Signal required return value of type gchararray but got gboolean")]
     fn test_signal_return_wrong_type() {
@@ -695,6 +696,7 @@ mod test {
         assert!(value.type_().is_a(&ChildObject::static_type()));
     }
 
+    #[cfg(not(all(windows, target_pointer_width = "32")))] //  Windows 32bits CI fails on this test
     #[test]
     #[should_panic(
         expected = "Signal required return value of type ChildObject but got GObject (actual SimpleObject)"

--- a/src/value.rs
+++ b/src/value.rs
@@ -1035,4 +1035,21 @@ mod tests {
             Some(vec![GString::from("123"), GString::from("456")])
         );
     }
+
+    #[test]
+    fn test_get() {
+        let v = 123.to_value();
+        assert_eq!(v.get(), Some(123));
+        assert_eq!(v.get::<i32>(), Some(123));
+        assert_eq!(v.get::<&str>(), None);
+
+        let some_v = Some("test").to_value();
+        assert_eq!(some_v.get::<i32>(), None);
+        assert_eq!(some_v.get::<&str>(), Some("test"));
+
+        let none_str: Option<&str> = None;
+        let none_v = none_str.to_value();
+        assert_eq!(none_v.get::<i32>(), None);
+        assert_eq!(none_v.get::<&str>(), None);
+    }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -48,8 +48,6 @@
 //! // `get_some` tries to get a value of the specified type
 //! // and returns an `Err` if the type doesn't match or if no value could be found
 //! assert_eq!(num.get_some::<i32>().unwrap(), 10);
-//! assert_eq!(hello.get::<String>().unwrap(), Some(String::from("Hello!")));
-//! assert_eq!(str_none.get::<String>(), Ok(None));
 //!
 //! // `typed` tries to convert a `Value` to `TypedValue`.
 //! let mut typed_num = num.downcast::<i32>().unwrap();

--- a/src/variant_type.rs
+++ b/src/variant_type.rs
@@ -435,12 +435,12 @@ mod tests {
     fn value() {
         let ty1 = VariantType::new("*").unwrap();
         let tyv = ty1.to_value();
-        let ty2 = tyv.get::<VariantType>().unwrap();
+        let ty2 = tyv.get_some::<VariantType>().unwrap();
         assert_eq!(ty1, ty2);
 
         let ty3 = VariantTy::new("*").unwrap();
         let tyv2 = ty1.to_value();
-        let ty4 = tyv2.get::<VariantType>().unwrap();
+        let ty4 = tyv2.get_some::<VariantType>().unwrap();
         assert_eq!(ty3, ty4);
 
         assert_eq!(VariantTy::static_type(), VariantTy::static_type());

--- a/src/variant_type.rs
+++ b/src/variant_type.rs
@@ -435,12 +435,12 @@ mod tests {
     fn value() {
         let ty1 = VariantType::new("*").unwrap();
         let tyv = ty1.to_value();
-        let ty2 = tyv.get_some::<VariantType>().unwrap();
+        let ty2 = tyv.get::<VariantType>().unwrap().unwrap();
         assert_eq!(ty1, ty2);
 
         let ty3 = VariantTy::new("*").unwrap();
         let tyv2 = ty1.to_value();
-        let ty4 = tyv2.get_some::<VariantType>().unwrap();
+        let ty4 = tyv2.get::<VariantType>().unwrap().unwrap();
         assert_eq!(ty3, ty4);
 
         assert_eq!(VariantTy::static_type(), VariantTy::static_type());


### PR DESCRIPTION
... and introduce `get_some` for types implementing `FromValue`.

First commit is for non-regression validation.

I'll update the other crates (gtk-rs & gstreamer-rs) when this is merged.

Fixes #510