### PR TITLE
value::GetError: add a constructor and make fields public

### DIFF
--- a/src/variant_type.rs
+++ b/src/variant_type.rs
@@ -351,7 +351,6 @@ impl Eq for VariantType {}
 mod tests {
     use super::*;
     use glib_sys;
-    use translate::*;
     use value::ToValue;
 
     unsafe fn equal<T, U>(ptr1: *const T, ptr2: *const U) -> bool {


### PR DESCRIPTION
The constructor allows instantiating the error outside of the module, e.g. for use in an `assert_eq!`.

People might want to access the public fields when handling the error. Besides, if the error was implemented using an `enum`, the fields would be public.

Fixes https://github.com/gtk-rs/glib/issues/515