### PR TITLE
Update to futures 0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ matrix:
   include:
     - os: linux
       rust: nightly
-      env: GTK=3.14 FEATURES=futures
+      env: GTK=3.14 FEATURES=
     - os: linux
       rust: nightly
-      env: GTK=3.24 FEATURES=v2_48,futures
+      env: GTK=3.24 FEATURES=v2_48
     - os: linux
       rust: beta
       env: GTK=3.14 FEATURES=
@@ -15,10 +15,10 @@ matrix:
       rust: beta
       env: GTK=3.24 FEATURES=v2_48
     - os: linux
-      rust: 1.36.0
+      rust: 1.39.0
       env: GTK=3.14 FEATURES=
     - os: linux
-      rust: 1.36.0
+      rust: 1.39.0
       env: GTK=3.24 FEATURES=v2_48
     - os: linux
       rust: stable
@@ -28,10 +28,10 @@ matrix:
       env: GTK=3.24 FEATURES=v2_48
     - os: osx
       rust: nightly
-      env: GTK=3.14 FEATURES=futures
+      env: GTK=3.14 FEATURES=
     # - os: osx
     #   rust: nightly
-    #   env: GTK=3.24 FEATURES=v2_48,futures
+    #   env: GTK=3.24 FEATURES=v2_48
     - os: osx
       rust: beta
       env: GTK=3.14 FEATURES=
@@ -39,10 +39,10 @@ matrix:
     #   rust: beta
     #   env: GTK=3.24 FEATURES=v2_48
     - os: osx
-      rust: 1.36.0
+      rust: 1.39.0
       env: GTK=3.14 FEATURES=
     # - os: osx
-    #   rust: 1.36.0
+    #   rust: 1.39.0
     #   env: GTK=3.24 FEATURES=v2_48
     - os: osx
       rust: stable
@@ -52,10 +52,10 @@ matrix:
     #   env: GTK=3.24 FEATURES=v2_48
     - os: linux
       rust: nightly
-      env: GTK=3.14 FEATURES=futures ARM=1 OTHER_TARGET="--target armv7-unknown-linux-gnueabihf"
+      env: GTK=3.14 FEATURES= ARM=1 OTHER_TARGET="--target armv7-unknown-linux-gnueabihf"
     - os: linux
       rust: nightly
-      env: GTK=3.24 FEATURES=v2_48,futures ARM=1 OTHER_TARGET="--target armv7-unknown-linux-gnueabihf"
+      env: GTK=3.24 FEATURES=v2_48 ARM=1 OTHER_TARGET="--target armv7-unknown-linux-gnueabihf"
 addons:
   apt:
     packages:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,11 @@ name = "glib"
 lazy_static = "1.2"
 libc = "0.2"
 bitflags = "1.0"
-futures-preview = { version = "0.3.0-alpha", optional = true }
+futures-core = "0.3"
+futures-task = "0.3"
+futures-executor = "0.3"
+futures-util = "0.3"
+futures-channel = "0.3"
 glib-sys = { git = "https://github.com/gtk-rs/sys" }
 gobject-sys = { git = "https://github.com/gtk-rs/sys" }
 
@@ -41,8 +45,7 @@ v2_54 = ["v2_52", "glib-sys/v2_54", "gobject-sys/v2_54"]
 v2_56 = ["v2_54", "glib-sys/v2_56"]
 v2_58 = ["v2_56", "glib-sys/v2_58"]
 v2_60 = ["v2_58", "glib-sys/v2_60"]
-futures = ["futures-preview"]
-dox = ["glib-sys/dox", "gobject-sys/dox", "futures"]
+dox = ["glib-sys/dox", "gobject-sys/dox"]
 
 [package.metadata.docs.rs]
 features = ["dox"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,8 +88,11 @@ pub extern crate glib_sys;
 #[doc(hidden)]
 pub extern crate gobject_sys;
 
-#[cfg(any(feature = "futures", feature = "dox"))]
-pub extern crate futures;
+extern crate futures_channel;
+extern crate futures_core;
+extern crate futures_executor;
+extern crate futures_task;
+extern crate futures_util;
 
 pub use byte_array::ByteArray;
 pub use bytes::Bytes;
@@ -179,11 +182,8 @@ pub use send_unique::{SendUnique, SendUniqueCell};
 #[macro_use]
 pub mod subclass;
 
-#[cfg(any(feature = "futures", feature = "dox"))]
 mod main_context_futures;
-#[cfg(any(feature = "futures", feature = "dox"))]
 mod source_futures;
-#[cfg(any(feature = "futures", feature = "dox"))]
 pub use source_futures::*;
 
 // Actual thread IDs can be reused by the OS once the old thread finished.

--- a/src/source_futures.rs
+++ b/src/source_futures.rs
@@ -2,10 +2,13 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
-use futures::channel::{mpsc, oneshot};
-use futures::prelude::*;
-use futures::task;
-use futures::task::Poll;
+use futures_channel::{mpsc, oneshot};
+use futures_core::future::Future;
+use futures_core::stream::Stream;
+use futures_core::task;
+use futures_core::task::Poll;
+use futures_util::future::FutureExt;
+use futures_util::stream::StreamExt;
 use std::marker::Unpin;
 use std::pin;
 
@@ -391,7 +394,7 @@ mod tests {
         let l_clone = l.clone();
         c.spawn(timeout_future(20).then(move |()| {
             l_clone.quit();
-            future::ready(())
+            futures_util::future::ready(())
         }));
 
         l.run();
@@ -411,7 +414,7 @@ mod tests {
                     .for_each(|()| {
                         *count = *count + 1;
 
-                        future::ready(())
+                        futures_util::future::ready(())
                     })
                     .map(|_| ()),
             );
@@ -433,7 +436,7 @@ mod tests {
                 sender.send(1).unwrap();
             });
 
-            receiver.then(|i| future::ready(i.unwrap()))
+            receiver.then(|i| futures_util::future::ready(i.unwrap()))
         }));
 
         assert_eq!(res, 1);


### PR DESCRIPTION
And require Rust 1.39.

We can't use async/await in the tests/etc yet because that requires
switching to the 2018 edition, and that is blocked by
https://github.com/gtk-rs/gir/issues/746