### PR TITLE
Don't leak missing Safety doc clippy warnings (#538)

### DIFF
--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -59,12 +59,14 @@ macro_rules! glib_boxed_wrapper {
             type Storage = &'a $crate::boxed::Boxed<$ffi_name, MemoryManager>;
 
             #[inline]
+            #[allow(clippy::missing_safety_doc)]
             fn to_glib_none(&'a self) -> $crate::translate::Stash<'a, *const $ffi_name, Self> {
                 let stash = $crate::translate::ToGlibPtr::to_glib_none(&self.0);
                 $crate::translate::Stash(stash.0, stash.1)
             }
 
             #[inline]
+            #[allow(clippy::missing_safety_doc)]
             fn to_glib_full(&self) -> *const $ffi_name {
                 $crate::translate::ToGlibPtr::to_glib_full(&self.0)
             }
@@ -75,6 +77,7 @@ macro_rules! glib_boxed_wrapper {
             type Storage = &'a mut $crate::boxed::Boxed<$ffi_name, MemoryManager>;
 
             #[inline]
+            #[allow(clippy::missing_safety_doc)]
             fn to_glib_none_mut(&'a mut self) -> $crate::translate::StashMut<'a, *mut $ffi_name, Self> {
                 let stash = $crate::translate::ToGlibPtrMut::to_glib_none_mut(&mut self.0);
                 $crate::translate::StashMut(stash.0, stash.1)
@@ -145,6 +148,7 @@ macro_rules! glib_boxed_wrapper {
         #[doc(hidden)]
         impl $crate::translate::FromGlibPtrNone<*mut $ffi_name> for $name {
             #[inline]
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_none(ptr: *mut $ffi_name) -> Self {
                 $name($crate::translate::from_glib_none(ptr))
             }
@@ -153,6 +157,7 @@ macro_rules! glib_boxed_wrapper {
         #[doc(hidden)]
         impl $crate::translate::FromGlibPtrNone<*const $ffi_name> for $name {
             #[inline]
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_none(ptr: *const $ffi_name) -> Self {
                 $name($crate::translate::from_glib_none(ptr))
             }
@@ -161,6 +166,7 @@ macro_rules! glib_boxed_wrapper {
         #[doc(hidden)]
         impl $crate::translate::FromGlibPtrFull<*mut $ffi_name> for $name {
             #[inline]
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_full(ptr: *mut $ffi_name) -> Self {
                 $name($crate::translate::from_glib_full(ptr))
             }
@@ -169,6 +175,7 @@ macro_rules! glib_boxed_wrapper {
         #[doc(hidden)]
         impl $crate::translate::FromGlibPtrBorrow<*mut $ffi_name> for $name {
             #[inline]
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_borrow(ptr: *mut $ffi_name) -> Self {
                 $name($crate::translate::from_glib_borrow(ptr))
             }
@@ -177,6 +184,7 @@ macro_rules! glib_boxed_wrapper {
         #[doc(hidden)]
         impl $crate::translate::FromGlibPtrBorrow<*const $ffi_name> for $name {
             #[inline]
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_borrow(ptr: *const $ffi_name) -> Self {
                 $crate::translate::from_glib_borrow(ptr as *mut $ffi_name)
             }
@@ -184,6 +192,7 @@ macro_rules! glib_boxed_wrapper {
 
         #[doc(hidden)]
         impl $crate::translate::FromGlibContainerAsVec<*mut $ffi_name, *mut *mut $ffi_name> for $name {
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_none_num_as_vec(ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
                 if num == 0 || ptr.is_null() {
                     return Vec::new();
@@ -196,12 +205,14 @@ macro_rules! glib_boxed_wrapper {
                 res
             }
 
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_container_num_as_vec(ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
                 let res = $crate::translate::FromGlibContainerAsVec::from_glib_none_num_as_vec(ptr, num);
                 $crate::glib_sys::g_free(ptr as *mut _);
                 res
             }
 
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_full_num_as_vec(ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
                 if num == 0 || ptr.is_null() {
                     return Vec::new();
@@ -218,14 +229,17 @@ macro_rules! glib_boxed_wrapper {
 
         #[doc(hidden)]
         impl $crate::translate::FromGlibPtrArrayContainerAsVec<*mut $ffi_name, *mut *mut $ffi_name> for $name {
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_none_as_vec(ptr: *mut *mut $ffi_name) -> Vec<Self> {
                 $crate::translate::FromGlibContainerAsVec::from_glib_none_num_as_vec(ptr, $crate::translate::c_ptr_array_len(ptr))
             }
 
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_container_as_vec(ptr: *mut *mut $ffi_name) -> Vec<Self> {
                 $crate::translate::FromGlibContainerAsVec::from_glib_container_num_as_vec(ptr, $crate::translate::c_ptr_array_len(ptr))
             }
 
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_full_as_vec(ptr: *mut *mut $ffi_name) -> Vec<Self> {
                 $crate::translate::FromGlibContainerAsVec::from_glib_full_num_as_vec(ptr, $crate::translate::c_ptr_array_len(ptr))
             }
@@ -242,6 +256,7 @@ macro_rules! glib_boxed_wrapper {
 
         #[doc(hidden)]
         impl<'a> $crate::value::FromValueOptional<'a> for $name {
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_value_optional(value: &$crate::Value) -> Option<Self> {
                 $crate::translate::from_glib_full($crate::gobject_sys::g_value_dup_boxed($crate::translate::ToGlibPtr::to_glib_none(value).0) as *mut $ffi_name)
             }
@@ -249,6 +264,7 @@ macro_rules! glib_boxed_wrapper {
 
         #[doc(hidden)]
         impl $crate::value::SetValue for $name {
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn set_value(value: &mut $crate::Value, this: &Self) {
                 $crate::gobject_sys::g_value_set_boxed($crate::translate::ToGlibPtrMut::to_glib_none_mut(value).0, $crate::translate::ToGlibPtr::<*const $ffi_name>::to_glib_none(this).0 as $crate::glib_sys::gpointer)
             }
@@ -256,6 +272,7 @@ macro_rules! glib_boxed_wrapper {
 
         #[doc(hidden)]
         impl $crate::value::SetValueOptional for $name {
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn set_value_optional(value: &mut $crate::Value, this: Option<&Self>) {
                 $crate::gobject_sys::g_value_set_boxed($crate::translate::ToGlibPtrMut::to_glib_none_mut(value).0, $crate::translate::ToGlibPtr::<*const $ffi_name>::to_glib_none(&this).0 as $crate::glib_sys::gpointer)
             }

--- a/src/file_error.rs
+++ b/src/file_error.rs
@@ -72,7 +72,7 @@ impl ErrorDomain for FileError {
         }
     }
 
-    #[allow(clippy::cyclomatic_complexity)]
+    #[allow(clippy::cognitive_complexity)]
     fn from(code: i32) -> Option<Self> {
         use self::FileError::*;
         match code {

--- a/src/main_context_futures.rs
+++ b/src/main_context_futures.rs
@@ -212,7 +212,7 @@ impl TaskSource {
 
             // Clone that we store in the task local data so that
             // it can be retrieved as needed
-            let res = executor.with_thread_default(|| {
+            executor.with_thread_default(|| {
                 let enter = futures_executor::enter().unwrap();
                 let mut context = Context::from_waker(&waker);
 
@@ -221,9 +221,7 @@ impl TaskSource {
                 drop(enter);
 
                 res
-            });
-
-            res
+            })
         } else {
             Poll::Ready(())
         }
@@ -314,7 +312,7 @@ impl MainContext {
 
             // Super-unsafe: We transmute here to get rid of the 'static lifetime
             let f = LocalFutureObj::new(Box::new(f));
-            let f: (LocalFutureObj<'static, ()>) = mem::transmute(f);
+            let f: LocalFutureObj<'static, ()> = mem::transmute(f);
 
             // And ensure that we are only ever running on this very thread.
             let f = f.into_future_obj();

--- a/src/object.rs
+++ b/src/object.rs
@@ -422,6 +422,7 @@ macro_rules! glib_object_wrapper {
 
         #[doc(hidden)]
         impl $crate::object::UnsafeFrom<$crate::object::ObjectRef> for $name {
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn unsafe_from(t: $crate::object::ObjectRef) -> Self {
                 $name(t, ::std::marker::PhantomData)
             }
@@ -563,6 +564,7 @@ macro_rules! glib_object_wrapper {
         impl $crate::translate::FromGlibPtrNone<*mut $ffi_name> for $name {
             #[inline]
             #[allow(clippy::cast_ptr_alignment)]
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_none(ptr: *mut $ffi_name) -> Self {
                 debug_assert!($crate::types::instance_of::<Self>(ptr as *const _));
                 $name($crate::translate::from_glib_none(ptr as *mut _), ::std::marker::PhantomData)
@@ -573,6 +575,7 @@ macro_rules! glib_object_wrapper {
         impl $crate::translate::FromGlibPtrNone<*const $ffi_name> for $name {
             #[inline]
             #[allow(clippy::cast_ptr_alignment)]
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_none(ptr: *const $ffi_name) -> Self {
                 debug_assert!($crate::types::instance_of::<Self>(ptr as *const _));
                 $name($crate::translate::from_glib_none(ptr as *mut _), ::std::marker::PhantomData)
@@ -583,6 +586,7 @@ macro_rules! glib_object_wrapper {
         impl $crate::translate::FromGlibPtrFull<*mut $ffi_name> for $name {
             #[inline]
             #[allow(clippy::cast_ptr_alignment)]
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_full(ptr: *mut $ffi_name) -> Self {
                 debug_assert!($crate::types::instance_of::<Self>(ptr as *const _));
                 $name($crate::translate::from_glib_full(ptr as *mut _), ::std::marker::PhantomData)
@@ -593,6 +597,7 @@ macro_rules! glib_object_wrapper {
         impl $crate::translate::FromGlibPtrBorrow<*mut $ffi_name> for $name {
             #[inline]
             #[allow(clippy::cast_ptr_alignment)]
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_borrow(ptr: *mut $ffi_name) -> Self {
                 debug_assert!($crate::types::instance_of::<Self>(ptr as *const _));
                 $name($crate::translate::from_glib_borrow(ptr as *mut _),
@@ -604,6 +609,7 @@ macro_rules! glib_object_wrapper {
         impl $crate::translate::FromGlibPtrBorrow<*const $ffi_name> for $name {
             #[inline]
             #[allow(clippy::cast_ptr_alignment)]
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_borrow(ptr: *const $ffi_name) -> Self {
                 $crate::translate::from_glib_borrow(ptr as *mut $ffi_name)
             }
@@ -611,6 +617,7 @@ macro_rules! glib_object_wrapper {
 
         #[doc(hidden)]
         impl $crate::translate::FromGlibContainerAsVec<*mut $ffi_name, *mut *mut $ffi_name> for $name {
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_none_num_as_vec(ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
                 if num == 0 || ptr.is_null() {
                     return Vec::new();
@@ -623,12 +630,14 @@ macro_rules! glib_object_wrapper {
                 res
             }
 
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_container_num_as_vec(ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
                 let res = $crate::translate::FromGlibContainerAsVec::from_glib_none_num_as_vec(ptr, num);
                 $crate::glib_sys::g_free(ptr as *mut _);
                 res
             }
 
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_full_num_as_vec(ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
                 if num == 0 || ptr.is_null() {
                     return Vec::new();
@@ -645,14 +654,17 @@ macro_rules! glib_object_wrapper {
 
         #[doc(hidden)]
         impl $crate::translate::FromGlibPtrArrayContainerAsVec<*mut $ffi_name, *mut *mut $ffi_name> for $name {
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_none_as_vec(ptr: *mut *mut $ffi_name) -> Vec<Self> {
                 $crate::translate::FromGlibContainerAsVec::from_glib_none_num_as_vec(ptr, $crate::translate::c_ptr_array_len(ptr))
             }
 
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_container_as_vec(ptr: *mut *mut $ffi_name) -> Vec<Self> {
                 $crate::translate::FromGlibContainerAsVec::from_glib_container_num_as_vec(ptr, $crate::translate::c_ptr_array_len(ptr))
             }
 
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_full_as_vec(ptr: *mut *mut $ffi_name) -> Vec<Self> {
                 $crate::translate::FromGlibContainerAsVec::from_glib_full_num_as_vec(ptr, $crate::translate::c_ptr_array_len(ptr))
             }
@@ -660,15 +672,18 @@ macro_rules! glib_object_wrapper {
 
         #[doc(hidden)]
         impl $crate::translate::FromGlibContainerAsVec<*mut $ffi_name, *const *mut $ffi_name> for $name {
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_none_num_as_vec(ptr: *const *mut $ffi_name, num: usize) -> Vec<Self> {
                 $crate::translate::FromGlibContainerAsVec::from_glib_none_num_as_vec(ptr as *mut *mut _, num)
             }
 
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_container_num_as_vec(_: *const *mut $ffi_name, _: usize) -> Vec<Self> {
                 // Can't free a *const
                 unimplemented!()
             }
 
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_full_num_as_vec(_: *const *mut $ffi_name, _: usize) -> Vec<Self> {
                 // Can't free a *const
                 unimplemented!()
@@ -677,15 +692,18 @@ macro_rules! glib_object_wrapper {
 
         #[doc(hidden)]
         impl $crate::translate::FromGlibPtrArrayContainerAsVec<*mut $ffi_name, *const *mut $ffi_name> for $name {
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_none_as_vec(ptr: *const *mut $ffi_name) -> Vec<Self> {
                 $crate::translate::FromGlibPtrArrayContainerAsVec::from_glib_none_as_vec(ptr as *mut *mut _)
             }
 
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_container_as_vec(_: *const *mut $ffi_name) -> Vec<Self> {
                 // Can't free a *const
                 unimplemented!()
             }
 
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_full_as_vec(_: *const *mut $ffi_name) -> Vec<Self> {
                 // Can't free a *const
                 unimplemented!()
@@ -726,6 +744,7 @@ macro_rules! glib_object_wrapper {
 
         #[doc(hidden)]
         impl<'a> $crate::value::FromValueOptional<'a> for $name {
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_value_optional(value: &$crate::Value) -> Option<Self> {
                 let obj = $crate::gobject_sys::g_value_get_object($crate::translate::ToGlibPtr::to_glib_none(value).0);
 
@@ -743,6 +762,7 @@ macro_rules! glib_object_wrapper {
         #[doc(hidden)]
         impl $crate::value::SetValue for $name {
             #[allow(clippy::cast_ptr_alignment)]
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn set_value(value: &mut $crate::Value, this: &Self) {
                 $crate::gobject_sys::g_value_set_object($crate::translate::ToGlibPtrMut::to_glib_none_mut(value).0, $crate::translate::ToGlibPtr::<*mut $ffi_name>::to_glib_none(this).0 as *mut $crate::gobject_sys::GObject)
             }
@@ -751,6 +771,7 @@ macro_rules! glib_object_wrapper {
         #[doc(hidden)]
         impl $crate::value::SetValueOptional for $name {
             #[allow(clippy::cast_ptr_alignment)]
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn set_value_optional(value: &mut $crate::Value, this: Option<&Self>) {
                 $crate::gobject_sys::g_value_set_object($crate::translate::ToGlibPtrMut::to_glib_none_mut(value).0, $crate::translate::ToGlibPtr::<*mut $ffi_name>::to_glib_none(&this).0 as *mut $crate::gobject_sys::GObject)
             }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -29,6 +29,7 @@ macro_rules! glib_shared_wrapper {
 
         #[doc(hidden)]
         impl<'a> $crate::value::FromValueOptional<'a> for $name {
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn from_value_optional(value: &$crate::Value) -> Option<Self> {
                 $crate::translate::from_glib_full($crate::gobject_sys::g_value_dup_boxed($crate::translate::ToGlibPtr::to_glib_none(value).0) as *mut $ffi_name)
             }
@@ -36,6 +37,7 @@ macro_rules! glib_shared_wrapper {
 
         #[doc(hidden)]
         impl $crate::value::SetValue for $name {
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn set_value(value: &mut $crate::Value, this: &Self) {
                 $crate::gobject_sys::g_value_set_boxed($crate::translate::ToGlibPtrMut::to_glib_none_mut(value).0, $crate::translate::ToGlibPtr::<*mut $ffi_name>::to_glib_none(this).0 as $crate::glib_sys::gpointer)
             }
@@ -43,6 +45,7 @@ macro_rules! glib_shared_wrapper {
 
         #[doc(hidden)]
         impl $crate::value::SetValueOptional for $name {
+            #[allow(clippy::missing_safety_doc)]
             unsafe fn set_value_optional(value: &mut $crate::Value, this: Option<&Self>) {
                 $crate::gobject_sys::g_value_set_boxed($crate::translate::ToGlibPtrMut::to_glib_none_mut(value).0, $crate::translate::ToGlibPtr::<*mut $ffi_name>::to_glib_none(&this).0 as $crate::glib_sys::gpointer)
             }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -48,6 +48,7 @@ impl ToGlib for Inhibit {
     }
 }
 
+#[allow(clippy::missing_safety_doc)]
 pub unsafe fn connect_raw<F>(
     receiver: *mut gobject_sys::GObject,
     signal_name: *const c_char,

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -124,6 +124,7 @@ pub trait Uninitialized {
 
 /// Returns an uninitialized value.
 #[inline]
+#[allow(clippy::missing_safety_doc)]
 pub unsafe fn uninitialized<T: Uninitialized>() -> T {
     T::uninitialized()
 }
@@ -913,7 +914,7 @@ impl<'a, P: Ptr, T: ToGlibContainerFromSlice<'a, P>> ToGlibPtr<'a, P> for [T] {
 
 #[allow(clippy::implicit_hasher)]
 impl<'a> ToGlibPtr<'a, *mut glib_sys::GHashTable> for HashMap<String, String> {
-    type Storage = (HashTable);
+    type Storage = HashTable;
 
     #[inline]
     fn to_glib_none(&self) -> Stash<'a, *mut glib_sys::GHashTable, Self> {
@@ -1126,18 +1127,21 @@ pub trait FromGlibPtrBorrow<P: Ptr>: Sized {
 
 /// Translate from a pointer type, transfer: none.
 #[inline]
+#[allow(clippy::missing_safety_doc)]
 pub unsafe fn from_glib_none<P: Ptr, T: FromGlibPtrNone<P>>(ptr: P) -> T {
     FromGlibPtrNone::from_glib_none(ptr)
 }
 
 /// Translate from a pointer type, transfer: full (assume ownership).
 #[inline]
+#[allow(clippy::missing_safety_doc)]
 pub unsafe fn from_glib_full<P: Ptr, T: FromGlibPtrFull<P>>(ptr: P) -> T {
     FromGlibPtrFull::from_glib_full(ptr)
 }
 
 /// Translate from a pointer type, borrowing the pointer.
 #[inline]
+#[allow(clippy::missing_safety_doc)]
 pub unsafe fn from_glib_borrow<P: Ptr, T: FromGlibPtrBorrow<P>>(ptr: P) -> T {
     FromGlibPtrBorrow::from_glib_borrow(ptr)
 }
@@ -1357,6 +1361,7 @@ pub trait FromGlibPtrContainer<P: Ptr, PP: Ptr>: FromGlibContainer<P, PP> + Size
     unsafe fn from_glib_full(ptr: PP) -> Self;
 }
 
+#[allow(clippy::missing_safety_doc)]
 pub unsafe fn c_ptr_array_len<P: Ptr>(mut ptr: *const P) -> usize {
     let mut len = 0;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -221,6 +221,7 @@ impl StaticType for Vec<String> {
 }
 
 #[inline]
+#[allow(clippy::missing_safety_doc)]
 pub unsafe fn instance_of<C: StaticType>(ptr: glib_sys::gconstpointer) -> bool {
     from_glib(gobject_sys::g_type_check_instance_is_a(
         ptr as *mut _,


### PR DESCRIPTION
With rustc 1.40.0, clippy checks that the `unsafe` functions come with
a `Safety` section. When running clippy on a downstream crate, the
macros such as `glib_wrapper!` leak the clippy warnings for the unsafe
functions.

Silence the warnings for now.

Fixes #538 