### PR TITLE
API additions for connecting non-Send closures and thread-safety fixes to the main context channel and futures

### DIFF
--- a/src/closure.rs
+++ b/src/closure.rs
@@ -10,6 +10,7 @@ use std::slice;
 
 use libc::{c_uint, c_void};
 
+use get_thread_id;
 use gobject_sys;
 use translate::{from_glib_none, mut_override, ToGlibPtr, ToGlibPtrMut, Uninitialized};
 use types::Type;
@@ -33,6 +34,36 @@ glib_wrapper! {
 impl Closure {
     pub fn new<F: Fn(&[Value]) -> Option<Value> + Send + Sync + 'static>(callback: F) -> Self {
         unsafe { Closure::new_unsafe(callback) }
+    }
+
+    pub fn new_local<F: Fn(&[Value]) -> Option<Value> + 'static>(callback: F) -> Self {
+        struct Wrapper<F> {
+            thread_id: usize,
+            callback: F,
+        }
+
+        impl<F> Drop for Wrapper<F> {
+            fn drop(&mut self) {
+                if self.thread_id != get_thread_id() {
+                    panic!("Local closure dropped on a different thread than where it was created");
+                }
+            }
+        }
+
+        let wrapper = Wrapper {
+            thread_id: get_thread_id(),
+            callback,
+        };
+
+        unsafe {
+            Closure::new_unsafe(move |values| {
+                if wrapper.thread_id != get_thread_id() {
+                    panic!("Local closure called on a different thread");
+                }
+
+                (wrapper.callback)(values)
+            })
+        }
     }
 
     pub unsafe fn new_unsafe<F: Fn(&[Value]) -> Option<Value>>(callback: F) -> Self {


### PR DESCRIPTION
After checking that the callback of the main context channel was always dropped from the correct thread, this check was actually failing often. I refactored the code now so that this can't happen anymore and we always ensure that non-Send values are only ever accessed from the correct thread.

Similar things happened with the GSource in the futures executor, which is also fixed and refactored now.

Overall the code should be much simpler now, and more correct!