### PR TITLE
Manually implement FFI code for GObject instead of using glib_shared_wrapper!

### DIFF
--- a/src/subclass/guard.rs
+++ b/src/subclass/guard.rs
@@ -2,9 +2,7 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
-use glib_sys;
 use gobject_sys;
-use std::ptr;
 
 #[macro_export]
 /// Macro for creating a [`FloatingReferenceGuard`].
@@ -27,25 +25,11 @@ macro_rules! glib_floating_reference_guard {
 /// This should be created via the [`floating_reference_guard!`] macro.
 ///
 /// [`floating_reference_guard!`]: ../../macro.floating_reference_guard.html
-pub struct FloatingReferenceGuard(ptr::NonNull<gobject_sys::GObject>);
+pub struct FloatingReferenceGuard;
 
 impl FloatingReferenceGuard {
     #[doc(hidden)]
-    pub unsafe fn new(obj: *mut gobject_sys::GObject) -> Option<FloatingReferenceGuard> {
-        assert!(!obj.is_null());
-        if gobject_sys::g_object_is_floating(obj) != glib_sys::GFALSE {
-            gobject_sys::g_object_ref_sink(obj);
-            Some(FloatingReferenceGuard(ptr::NonNull::new_unchecked(obj)))
-        } else {
-            None
-        }
-    }
-}
-
-impl Drop for FloatingReferenceGuard {
-    fn drop(&mut self) {
-        unsafe {
-            gobject_sys::g_object_force_floating(self.0.as_ptr());
-        }
+    pub unsafe fn new(_obj: *mut gobject_sys::GObject) -> Option<FloatingReferenceGuard> {
+        None
     }
 }


### PR DESCRIPTION
    This way we can implement special cases more correctly:
    - g_value_get_boxed() is invalid for GObjects
    - Debug impl can print the actual type
    - Only from_glib_none() will ever steal floating references and e.g.
      cloning does not, see https://github.com/gtk-rs/glib/issues/545
    
    After this the only places where we would steal floating references from
    C code would be when explicitly calling from_glib_none() somewhere. That
    is, when we call a function and get a (transfer none) reference to an
    object back. (transfer floating) is an alias for this.
    
    Especially, cloning and from_glib_borrow() would never steal floating
    references, and because of this it is very important to only ever use
    from_glib_borrow() inside callbacks, signal handlers and virtual method
    trampolines.

----

@EPashkin @GuillaumeGomez @federicomenaquintero @MathieuDuponchelle @ebassi Does the above make sense to you?

This is basically the workaround for C code passing us floating references that we should not actually own. We try now very hard to not steal them, i.e. the only place where we would steal them now is if a function is returning a `(transfer none)` object to use (return value or out parameter), or more specifically if `from_glib_none()` is used. We won't anymore steal floating references passed into: callbacks, signal handlers, virtual methods and passed to us via `GValue`s but keep the floating flag intact to have C worry about this mess instead.