### PR TITLE
Use NonZeroU64/32 for SignalHandlerId/SourceId

### DIFF
--- a/src/signal.rs
+++ b/src/signal.rs
@@ -9,18 +9,19 @@ use gobject_sys::{self, GCallback};
 use libc::{c_char, c_ulong, c_void};
 use object::ObjectType;
 use std::mem;
+use std::num::NonZeroU64;
 use translate::{from_glib, FromGlib, ToGlib, ToGlibPtr};
 
 /// The id of a signal that is returned by `connect`.
 #[derive(Debug, Eq, PartialEq)]
-pub struct SignalHandlerId(c_ulong);
+pub struct SignalHandlerId(NonZeroU64);
 
 impl ToGlib for SignalHandlerId {
     type GlibType = c_ulong;
 
     #[inline]
     fn to_glib(&self) -> c_ulong {
-        self.0
+        self.0.get() as c_ulong
     }
 }
 
@@ -28,7 +29,7 @@ impl FromGlib<c_ulong> for SignalHandlerId {
     #[inline]
     fn from_glib(val: c_ulong) -> SignalHandlerId {
         assert_ne!(val, 0);
-        SignalHandlerId(val)
+        SignalHandlerId(unsafe { NonZeroU64::new_unchecked(val as u64) })
     }
 }
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -10,8 +10,6 @@ use std::mem::transmute;
 use std::num::NonZeroU32;
 #[cfg(unix)]
 use std::os::unix::io::RawFd;
-use std::process;
-use std::thread;
 use translate::{from_glib, from_glib_full, FromGlib, ToGlib, ToGlibPtr};
 #[cfg(any(unix, feature = "dox"))]
 use IOCondition;
@@ -84,38 +82,6 @@ impl ToGlib for Continue {
     #[inline]
     fn to_glib(&self) -> gboolean {
         self.0.to_glib()
-    }
-}
-
-/// Unwinding propagation guard. Aborts the process if destroyed while
-/// panicking.
-#[deprecated(note = "Rustc has this functionality built-in since 1.26.0")]
-pub struct CallbackGuard(());
-
-#[allow(deprecated)]
-impl CallbackGuard {
-    pub fn new() -> CallbackGuard {
-        CallbackGuard(())
-    }
-}
-
-#[allow(deprecated)]
-impl Default for CallbackGuard {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[allow(deprecated)]
-impl Drop for CallbackGuard {
-    fn drop(&mut self) {
-        use std::io::stderr;
-        use std::io::Write;
-
-        if thread::panicking() {
-            let _ = stderr().write(b"Uncaught panic, exiting\n");
-            process::abort();
-        }
     }
 }
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -7,6 +7,7 @@ use glib_sys::{self, gboolean, gpointer};
 use libc::c_int as RawFd;
 use std::cell::RefCell;
 use std::mem::transmute;
+use std::num::NonZeroU32;
 #[cfg(unix)]
 use std::os::unix::io::RawFd;
 use std::process;
@@ -20,7 +21,7 @@ use Source;
 
 /// The id of a source that is returned by `idle_add` and `timeout_add`.
 #[derive(Debug, Eq, PartialEq)]
-pub struct SourceId(u32);
+pub struct SourceId(NonZeroU32);
 
 #[doc(hidden)]
 impl ToGlib for SourceId {
@@ -28,7 +29,7 @@ impl ToGlib for SourceId {
 
     #[inline]
     fn to_glib(&self) -> u32 {
-        self.0
+        self.0.get()
     }
 }
 
@@ -37,7 +38,7 @@ impl FromGlib<u32> for SourceId {
     #[inline]
     fn from_glib(val: u32) -> SourceId {
         assert_ne!(val, 0);
-        SourceId(val)
+        SourceId(unsafe { NonZeroU32::new_unchecked(val) })
     }
 }
 

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -129,34 +129,6 @@ pub unsafe fn uninitialized<T: Uninitialized>() -> T {
     T::uninitialized()
 }
 
-pub trait ToBool: Copy {
-    fn to_bool(self) -> bool;
-}
-
-impl ToBool for bool {
-    #[inline]
-    fn to_bool(self) -> bool {
-        self
-    }
-}
-
-impl ToBool for glib_sys::gboolean {
-    #[inline]
-    fn to_bool(self) -> bool {
-        self != glib_sys::GFALSE
-    }
-}
-
-/// Returns `Some(val)` if the condition is true and `None` otherwise.
-#[inline]
-pub fn some_if<B: ToBool, T, F: FnOnce() -> T>(cond: B, f: F) -> Option<T> {
-    if cond.to_bool() {
-        Some(f())
-    } else {
-        None
-    }
-}
-
 /// Helper type that stores temporary values used for translation.
 ///
 /// `P` is the foreign type pointer and the first element of the tuple.


### PR DESCRIPTION
These allows for some further optimizations.

Also do some minor cleanup of unused code.