### PR TITLE
Derive fmt::Debug for a few more types

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -1158,6 +1158,7 @@ macro_rules! glib_object_wrapper {
 
     (@class_impl $name:ident, $ffi_class_name:path, $rust_class_name:ident) => {
         #[repr(C)]
+        #[derive(Debug)]
         pub struct $rust_class_name($ffi_class_name);
 
         unsafe impl $crate::object::IsClassFor for $rust_class_name {
@@ -1916,6 +1917,7 @@ glib_wrapper! {
     }
 }
 
+#[derive(Debug)]
 pub struct WeakRef<T: ObjectType>(Box<gobject_sys::GWeakRef>, PhantomData<*const T>);
 
 impl<T: ObjectType> WeakRef<T> {
@@ -1979,6 +1981,7 @@ unsafe impl<T: ObjectType + Send + Sync> Send for WeakRef<T> {}
 /// Trying to upgrade the weak reference from another thread than the one
 /// where it was created on will panic but dropping or cloning can be done
 /// safely from any thread.
+#[derive(Debug)]
 pub struct SendWeakRef<T: ObjectType>(WeakRef<T>, Option<usize>);
 
 impl<T: ObjectType> SendWeakRef<T> {
@@ -2029,6 +2032,7 @@ impl<T: ObjectType> From<WeakRef<T>> for SendWeakRef<T> {
 unsafe impl<T: ObjectType> Sync for SendWeakRef<T> {}
 unsafe impl<T: ObjectType> Send for SendWeakRef<T> {}
 
+#[derive(Debug)]
 pub struct BindingBuilder<'a> {
     source: &'a ObjectRef,
     source_property: &'a str,

--- a/src/subclass/simple.rs
+++ b/src/subclass/simple.rs
@@ -9,12 +9,24 @@
 use super::prelude::*;
 use object::ObjectType;
 
+use std::fmt;
 use std::ops;
 
 /// A simple instance struct that does not store any additional data.
 #[repr(C)]
 pub struct InstanceStruct<T: ObjectSubclass> {
     parent: <T::ParentType as ObjectType>::GlibType,
+}
+
+impl<T: ObjectSubclass> fmt::Debug for InstanceStruct<T>
+where
+    <T::ParentType as ObjectType>::GlibType: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("InstanceStruct")
+            .field("parent", &self.parent)
+            .finish()
+    }
 }
 
 unsafe impl<T: ObjectSubclass> super::types::InstanceStruct for InstanceStruct<T> {
@@ -26,6 +38,17 @@ unsafe impl<T: ObjectSubclass> super::types::InstanceStruct for InstanceStruct<T
 #[repr(C)]
 pub struct ClassStruct<T: ObjectSubclass> {
     parent_class: <T::ParentType as ObjectType>::GlibClassType,
+}
+
+impl<T: ObjectSubclass> fmt::Debug for ClassStruct<T>
+where
+    <T::ParentType as ObjectType>::GlibClassType: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("InstanceStruct")
+            .field("parent_class", &self.parent_class)
+            .finish()
+    }
 }
 
 unsafe impl<T: ObjectSubclass> super::types::ClassStruct for ClassStruct<T> {


### PR DESCRIPTION
Especially for WeakRefs this is rather useful to have.