### PR TITLE
Implements FromGlibPtrFull<*const T> for boxed types.

### DIFF
--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -471,7 +471,7 @@ impl<T: 'static, MM: BoxedMemoryManager<T>> FromGlibPtrFull<*const T> for Boxed<
     unsafe fn from_glib_full(ptr: *const T) -> Self {
         assert!(!ptr.is_null());
         Boxed {
-            inner: AnyBox::ForeignOwned(ptr::NonNull::new_unchecked(ptr as *mut _)),
+            inner: AnyBox::ForeignOwned(ptr::NonNull::new_unchecked(ptr as *mut T)),
             _dummy: PhantomData,
         }
     }

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -473,7 +473,7 @@ impl<T: 'static, MM: BoxedMemoryManager<T>> FromGlibPtrFull<*const T> for Boxed<
         let ptr = MM::copy(ptr);
         Boxed {
             inner: AnyBox::Native(Box::from_raw(ptr)),
-            _dummy: PhantomData
+            _dummy: PhantomData,
         }
     }
 }

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -470,9 +470,8 @@ impl<T: 'static, MM: BoxedMemoryManager<T>> FromGlibPtrFull<*const T> for Boxed<
     #[inline]
     unsafe fn from_glib_full(ptr: *const T) -> Self {
         assert!(!ptr.is_null());
-        let ptr = MM::copy(ptr);
         Boxed {
-            inner: AnyBox::Native(Box::from_raw(ptr)),
+            inner: AnyBox::ForeignOwned(ptr::NonNull::new_unchecked(ptr as *mut _)),
             _dummy: PhantomData,
         }
     }

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -170,6 +170,15 @@ macro_rules! glib_boxed_wrapper {
         }
 
         #[doc(hidden)]
+        impl $crate::translate::FromGlibPtrFull<*const $ffi_name> for $name {
+            #[inline]
+            #[allow(clippy::missing_safety_doc)]
+            unsafe fn from_glib_full(ptr: *const $ffi_name) -> Self {
+                $name($crate::translate::from_glib_full(ptr))
+            }
+        }
+
+        #[doc(hidden)]
         impl $crate::translate::FromGlibPtrBorrow<*mut $ffi_name> for $name {
             #[inline]
             #[allow(clippy::missing_safety_doc)]
@@ -453,6 +462,18 @@ impl<T: 'static, MM: BoxedMemoryManager<T>> FromGlibPtrFull<*mut T> for Boxed<T,
         Boxed {
             inner: AnyBox::ForeignOwned(ptr::NonNull::new_unchecked(ptr)),
             _dummy: PhantomData,
+        }
+    }
+}
+
+impl<T: 'static, MM: BoxedMemoryManager<T>> FromGlibPtrFull<*const T> for Boxed<T, MM> {
+    #[inline]
+    unsafe fn from_glib_full(ptr: *const T) -> Self {
+        assert!(!ptr.is_null());
+        let ptr = MM::copy(ptr);
+        Boxed {
+            inner: AnyBox::Native(Box::from_raw(ptr)),
+            _dummy: PhantomData
         }
     }
 }


### PR DESCRIPTION
The aim is to solve issue: 865 of the gir repository [865](https://github.com/gtk-rs/gir/issues/865)

AnyBox::Native(Box<T>) looks like the suitable variant for a fully owned *const T
Is checking non_null sufficient here before converting the raw pointer to a box?
I'm assuming here MM::copy() assures other type requirements are met.
Is this correct? 
While this solution makes my code compile and most of this impl is copied and adapted from other impls in the same file, there may well be things I have missed or misunderstood. Therefore a close look at what I've done is much appreciated.
