### PR TITLE
Don't store subclass impl/private data in an Option<T>

### DIFF
--- a/src/subclass/object.rs
+++ b/src/subclass/object.rs
@@ -565,6 +565,17 @@ mod test {
     }
 
     #[test]
+    fn test_create_child_object() {
+        let type_ = ChildObject::get_type();
+        let obj = Object::new(type_, &[]).unwrap();
+
+        // ChildObject is a zero-sized type and we map that to the same pointer as the object
+        // itself. No private/impl data is allocated for zero-sized types.
+        let imp = ChildObject::from_instance(&obj);
+        assert_eq!(imp as *const _ as *const (), obj.as_ptr() as *const _);
+    }
+
+    #[test]
     fn test_set_properties() {
         let obj = Object::new(SimpleObject::get_type(), &[]).unwrap();
 

--- a/src/subclass/types.rs
+++ b/src/subclass/types.rs
@@ -454,6 +454,16 @@ pub fn register_type<T: ObjectSubclass>() -> Type
 where
     <<T as ObjectSubclass>::ParentType as ObjectType>::RustClassType: IsSubclassable<T>,
 {
+    // GLib aligns the type private data to two gsizes so we can't safely store any type there that
+    // requires a bigger alignment.
+    if mem::align_of::<T>() > 2 * mem::size_of::<usize>() {
+        panic!(
+            "Alignment {} of type not supported, bigger than {}",
+            mem::align_of::<T>(),
+            2 * mem::size_of::<usize>(),
+        );
+    }
+
     unsafe {
         use std::ffi::CString;
 

--- a/src/subclass/types.rs
+++ b/src/subclass/types.rs
@@ -427,16 +427,13 @@ unsafe extern "C" fn instance_init<T: ObjectSubclass>(
 }
 
 unsafe extern "C" fn finalize<T: ObjectSubclass>(obj: *mut gobject_sys::GObject) {
-    // Retrieve the private struct, take it out of its storage and
-    // drop it for freeing all associated memory.
+    // Retrieve the private struct and drop it for freeing all associated memory.
     let mut data = T::type_data();
     let private_offset = (*data.as_mut()).private_offset;
     let ptr: *mut u8 = obj as *mut _ as *mut u8;
     let priv_ptr = ptr.offset(private_offset);
     let imp_storage = priv_ptr as *mut T;
-
-    let imp = ptr::read(imp_storage);
-    drop(imp);
+    ptr::drop_in_place(imp_storage);
 
     // Chain up to the parent class' finalize implementation, if any.
     let parent_class = &*(data.as_ref().get_parent_class() as *const gobject_sys::GObjectClass);


### PR DESCRIPTION
We don't know the exact memory layout of the Option<T> in relation to T
so can't easily go from a *const T to the surrounding *const Option<T>.

Since nightly from 2020-02-12 using both pointer types interchangeably
causes segmentation faults as their memory layouts are not actually
compatible and never were, but due to some compiler changes this
actually causes crashes at runtime now.

See https://github.com/rust-lang/rust/issues/69102 for details.

As an Option<_> was only used for some paranoid runtime checks that are
not really needed, simply store T directly as impl/private data of
subclasses.

This has the side-effect of having zero-sized impl/private data types to
actually occupy zero bytes of memory, and in some other cases to save a
few bytes of the allocation.

----

CC @EPashkin @GuillaumeGomez 