### PR TITLE
Don't pass an owned string to g_quark_from_static_string()

### DIFF
--- a/src/quark.rs
+++ b/src/quark.rs
@@ -13,7 +13,7 @@ pub struct Quark(glib_sys::GQuark);
 
 impl Quark {
     pub fn from_string(s: &str) -> Quark {
-        unsafe { from_glib(glib_sys::g_quark_from_static_string(s.to_glib_full())) }
+        unsafe { from_glib(glib_sys::g_quark_from_string(s.to_glib_none().0)) }
     }
 
     #[allow(clippy::trivially_copy_pass_by_ref)]


### PR DESCRIPTION
When called more than once or for a quark that already exists otherwise,
we would always leak the string. Instead pass an unowned string to
g_quark_from_string().

----

CC @GuillaumeGomez @EPashkin 