### PR TITLE
Add print in case an upgrade failed

### DIFF
--- a/src/clone.rs
+++ b/src/clone.rs
@@ -135,13 +135,27 @@ macro_rules! to_type_after {
     (@weak $variable:ident , $return_value:expr) => {
         let $variable = match $crate::clone::Upgrade::upgrade(&$variable) {
             Some(val) => val,
-            None => return ($return_value)(),
+            None => {
+                $crate::g_debug!(
+                    $crate::CLONE_MACRO_LOG_DOMAIN,
+                    "Failed to upgrade {}",
+                    stringify!($variable)
+                );
+                return ($return_value)();
+            }
         };
     };
     (as $rename:ident @weak $($variable:ident).+ , $return_value:expr) => {
         let $rename = match $crate::clone::Upgrade::upgrade(&$rename) {
             Some(val) => val,
-            None => return ($return_value)(),
+            None => {
+                $crate::g_debug!(
+                    $crate::CLONE_MACRO_LOG_DOMAIN,
+                    "Failed to upgrade {} {}",
+                    stringify!($rename), "yolo",
+                );
+                return ($return_value)();
+            }
         };
     };
     ($(as $rename:ident)? @strong $($variable:ident).+ , $return_value:expr) => {};

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -195,16 +195,19 @@ macro_rules! to_return_value {
 /// In case something goes wrong inside the `clone!` macro, we use the [`g_debug`] macro. Meaning
 /// that if you want to see these debug messages, you'll have to set the `G_MESSAGES_DEBUG`
 /// environment variable when running your code (either in the code directly or when running the
-/// binary):
+/// binary) to either "all" or [`CLONE_MACRO_LOG_DOMAIN`][crate::CLONE_MACRO_LOG_DOMAIN]:
 ///
 /// ```rust
-/// ::std::env::set_var("G_MESSAGES_DEBUG", "1");
+/// use glib::CLONE_MACRO_LOG_DOMAIN;
+///
+/// ::std::env::set_var("G_MESSAGES_DEBUG", CLONE_MACRO_LOG_DOMAIN);
+/// ::std::env::set_var("G_MESSAGES_DEBUG", "all");
 /// ```
 ///
 /// Or:
 ///
 /// ```bash
-/// $ G_MESSAGES_DEBUG=1 ./binary
+/// $ G_MESSAGES_DEBUG=all ./binary
 /// ```
 ///
 /// ### Passing a strong reference

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -122,13 +122,19 @@ macro_rules! to_type_after {
     (@default-panic, @weak $variable:ident) => {
         let $variable = match $crate::clone::Upgrade::upgrade(&$variable) {
             Some(val) => val,
-            None => panic!("failed to upgrade {}", stringify!($variable)),
+            None => panic!(
+                "failed to upgrade `{}` (if you don't want to panic, use @default-return)",
+                stringify!($variable)
+            ),
         };
     };
     (as $rename:ident @default-panic, @weak $($variable:ident).+) => {
         let $rename = match $crate::clone::Upgrade::upgrade(&$rename) {
             Some(val) => val,
-            None => panic!("failed to upgrade {}", stringify!($rename)),
+            None => panic!(
+                "failed to upgrade `{}` (if you don't want to panic, use @default-return)",
+                stringify!($rename)
+            ),
         };
     };
     ($(as $rename:ident)? @default-panic, @strong $($variable:ident).+) => {};
@@ -152,7 +158,8 @@ macro_rules! to_type_after {
                 $crate::g_debug!(
                     $crate::CLONE_MACRO_LOG_DOMAIN,
                     "Failed to upgrade {} {}",
-                    stringify!($rename), "yolo",
+                    stringify!($rename),
+                    "yolo",
                 );
                 return ($return_value)();
             }
@@ -182,6 +189,23 @@ macro_rules! to_return_value {
 /// If upgrading the weak reference to a strong reference inside the closure is failing, the
 /// closure is immediately returning an optional default return value. If none is provided, `()` is
 /// returned.
+///
+/// ### Debugging
+///
+/// In case something goes wrong inside the `clone!` macro, we use the [`g_debug`] macro. Meaning
+/// that if you want to see these debug messages, you'll have to set the `G_MESSAGES_DEBUG`
+/// environment variable when running your code (either in the code directly or when running the
+/// binary):
+///
+/// ```rust
+/// ::std::env::set_var("G_MESSAGES_DEBUG", "1");
+/// ```
+///
+/// Or:
+///
+/// ```bash
+/// $ G_MESSAGES_DEBUG=1 ./binary
+/// ```
 ///
 /// ### Passing a strong reference
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,9 @@ pub use source_futures::*;
 mod thread_pool;
 pub use thread_pool::ThreadPool;
 
+/// This is the log domain used by the [`clone!`][crate::clone] macro. If you want to use a custom
+/// logger (it prints to stdout by default), you can set your own logger using the corresponding
+/// `log` functions.
 pub const CLONE_MACRO_LOG_DOMAIN: &str = "glib-rs-clone";
 
 // Actual thread IDs can be reused by the OS once the old thread finished.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,8 @@ pub use source_futures::*;
 mod thread_pool;
 pub use thread_pool::ThreadPool;
 
+pub const CLONE_MACRO_LOG_DOMAIN: &str = "clone-macro-debug";
+
 // Actual thread IDs can be reused by the OS once the old thread finished.
 // This works around it by using our own counter for threads.
 //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,7 @@ pub use source_futures::*;
 mod thread_pool;
 pub use thread_pool::ThreadPool;
 
-pub const CLONE_MACRO_LOG_DOMAIN: &str = "clone-macro-debug";
+pub const CLONE_MACRO_LOG_DOMAIN: &str = "glib-rs-clone";
 
 // Actual thread IDs can be reused by the OS once the old thread finished.
 // This works around it by using our own counter for threads.


### PR DESCRIPTION
Just one question: should we put it behind a feature instead?

cc @sdroege @EPashkin 