### PR TITLE
glib-macros: add GBoxed derive

### DIFF
--- a/glib-macros/Cargo.toml
+++ b/glib-macros/Cargo.toml
@@ -18,6 +18,7 @@ proc-macro-error = "0.4"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "1.0"
+proc-macro-crate = "0.1"
 
 [lib]
 proc-macro = true

--- a/glib-macros/Cargo.toml
+++ b/glib-macros/Cargo.toml
@@ -23,5 +23,5 @@ syn = "1.0"
 proc-macro = true
 
 [dev-dependencies]
-glib = { git = "https://github.com/gtk-rs/glib" }
+glib = { path = ".." }
 gobject-sys = { git = "https://github.com/gtk-rs/sys" }

--- a/glib-macros/src/gboxed_derive.rs
+++ b/glib-macros/src/gboxed_derive.rs
@@ -2,8 +2,9 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
-use proc_macro2::{Ident, TokenStream};
+use proc_macro2::{Ident, Span, TokenStream};
 use proc_macro_error::abort_call_site;
+use proc_macro_crate::crate_name;
 use quote::quote;
 
 use crate::utils::{find_attribute_meta, find_nested_meta, parse_type_name};
@@ -40,12 +41,12 @@ fn gen_ptr_to_option(name: &Ident, nullable: bool) -> TokenStream {
     }
 }
 
-fn gen_impl_from_value(name: &Ident) -> TokenStream {
+fn gen_impl_from_value(name: &Ident, crate_ident: &Ident) -> TokenStream {
     quote! {
-        impl<'a> ::glib::value::FromValue<'a> for &'a #name {
-            unsafe fn from_value(value: &'a ::glib::value::Value) -> Self {
-                let ptr = ::glib::gobject_sys::g_value_get_boxed(
-                    ::glib::translate::ToGlibPtr::to_glib_none(value).0,
+        impl<'a> #crate_ident::value::FromValue<'a> for &'a #name {
+            unsafe fn from_value(value: &'a #crate_ident::value::Value) -> Self {
+                let ptr = #crate_ident::gobject_sys::g_value_get_boxed(
+                    #crate_ident::translate::ToGlibPtr::to_glib_none(value).0,
                 );
                 assert!(!ptr.is_null());
                 &*(ptr as *mut #name)
@@ -65,6 +66,16 @@ pub fn impl_gboxed(input: &syn::DeriveInput) -> TokenStream {
         ),
     };
 
+    let crate_name = match crate_name("glib") {
+        Ok(x) => x,
+	Err(_) => {
+            // In case we use it directly from glib itself (it cannot find glib as a dependency
+	    // in this case)
+            "glib".to_owned()
+	}
+    };
+    let crate_ident = Ident::new(&crate_name, Span::call_site());
+
     let meta = find_attribute_meta(&input.attrs, "gboxed")
         .unwrap()
         .unwrap();
@@ -73,7 +84,7 @@ pub fn impl_gboxed(input: &syn::DeriveInput) -> TokenStream {
     let option_to_ptr = gen_option_to_ptr(nullable);
     let ptr_to_option = gen_ptr_to_option(name, nullable);
     let impl_from_value = if !nullable {
-        gen_impl_from_value(name)
+        gen_impl_from_value(name, &crate_ident)
     } else {
         quote! {}
     };
@@ -82,12 +93,12 @@ pub fn impl_gboxed(input: &syn::DeriveInput) -> TokenStream {
         impl BoxedType for #name {
             const NAME: &'static str = #gtype_name;
 
-            fn get_type() -> ::glib::Type {
-                static mut TYPE_: ::glib::Type = ::glib::Type::Invalid;
+            fn get_type() -> #crate_ident::Type {
+                static mut TYPE_: #crate_ident::Type = #crate_ident::Type::Invalid;
                 static ONCE: ::std::sync::Once = ::std::sync::Once::new();
 
                 ONCE.call_once(|| {
-                    let type_ = ::glib::subclass::register_boxed_type::<Self>();
+                    let type_ = #crate_ident::subclass::register_boxed_type::<Self>();
                     unsafe {
                         TYPE_ = type_;
                     }
@@ -97,36 +108,36 @@ pub fn impl_gboxed(input: &syn::DeriveInput) -> TokenStream {
             }
         }
 
-        impl ::glib::StaticType for #name {
-            fn static_type() -> ::glib::Type {
-                <#name as ::glib::subclass::boxed::BoxedType>::get_type()
+        impl #crate_ident::StaticType for #name {
+            fn static_type() -> #crate_ident::Type {
+                <#name as #crate_ident::subclass::boxed::BoxedType>::get_type()
             }
         }
 
-        impl ::glib::value::SetValue for #name {
-            unsafe fn set_value(value: &mut ::glib::value::Value, this: &Self) {
+        impl #crate_ident::value::SetValue for #name {
+            unsafe fn set_value(value: &mut #crate_ident::value::Value, this: &Self) {
                 let ptr: *mut #name = Box::into_raw(Box::new(this.clone()));
-                ::glib::gobject_sys::g_value_take_boxed(
-                    ::glib::translate::ToGlibPtrMut::to_glib_none_mut(value).0,
+                #crate_ident::gobject_sys::g_value_take_boxed(
+                    #crate_ident::translate::ToGlibPtrMut::to_glib_none_mut(value).0,
                     ptr as *mut _,
                 );
             }
         }
 
-        impl ::glib::value::SetValueOptional for #name {
-            unsafe fn set_value_optional(value: &mut ::glib::value::Value, this: Option<&Self>) {
+        impl #crate_ident::value::SetValueOptional for #name {
+            unsafe fn set_value_optional(value: &mut #crate_ident::value::Value, this: Option<&Self>) {
                 let ptr: *mut #name = #option_to_ptr;
-                ::glib::gobject_sys::g_value_take_boxed(
-                    ::glib::translate::ToGlibPtrMut::to_glib_none_mut(value).0,
+                #crate_ident::gobject_sys::g_value_take_boxed(
+                    #crate_ident::translate::ToGlibPtrMut::to_glib_none_mut(value).0,
                     ptr as *mut _,
                 );
             }
         }
 
-        impl<'a> ::glib::value::FromValueOptional<'a> for &'a #name {
-            unsafe fn from_value_optional(value: &'a ::glib::value::Value) -> Option<Self> {
-                let ptr = ::glib::gobject_sys::g_value_get_boxed(
-                    ::glib::translate::ToGlibPtr::to_glib_none(value).0,
+        impl<'a> #crate_ident::value::FromValueOptional<'a> for &'a #name {
+            unsafe fn from_value_optional(value: &'a #crate_ident::value::Value) -> Option<Self> {
+                let ptr = #crate_ident::gobject_sys::g_value_get_boxed(
+                    #crate_ident::translate::ToGlibPtr::to_glib_none(value).0,
                 );
                 #ptr_to_option
             }

--- a/glib-macros/src/gboxed_derive.rs
+++ b/glib-macros/src/gboxed_derive.rs
@@ -1,0 +1,30 @@
+// Copyright 2020, The Gtk-rs Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+use proc_macro2::TokenStream;
+use proc_macro_error::abort_call_site;
+use quote::quote;
+
+use crate::utils::parse_type_name;
+
+pub fn impl_gboxed(input: &syn::DeriveInput) -> TokenStream {
+    let name = &input.ident;
+
+    let gtype_name = match parse_type_name(&input, "gboxed") {
+        Ok(v) => v,
+        Err(e) => abort_call_site!(
+            "{}: derive(GBoxed) requires #[gboxed(type_name = \"BoxedTypeName\")]",
+            e
+        ),
+    };
+
+    quote! {
+        impl BoxedType for #name {
+            const NAME: &'static str = #gtype_name;
+            glib_boxed_type!();
+        }
+
+        glib_boxed_derive_traits!(#name);
+    }
+}

--- a/glib-macros/src/gboxed_derive.rs
+++ b/glib-macros/src/gboxed_derive.rs
@@ -2,11 +2,57 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
-use proc_macro2::TokenStream;
+use proc_macro2::{Ident, TokenStream};
 use proc_macro_error::abort_call_site;
 use quote::quote;
 
-use crate::utils::parse_type_name;
+use crate::utils::{find_attribute_meta, find_nested_meta, parse_type_name};
+
+fn gen_option_to_ptr(nullable: bool) -> TokenStream {
+    if nullable {
+        quote! {
+            match this {
+                Some(this) => Box::into_raw(Box::new(this.clone())),
+                None => std::ptr::null_mut(),
+            };
+        }
+    } else {
+        quote! {
+            Box::into_raw(Box::new(this.expect("None not allowed").clone()));
+        }
+    }
+}
+
+fn gen_ptr_to_option(name: &Ident, nullable: bool) -> TokenStream {
+    if nullable {
+        quote! {
+            if ptr.is_null() {
+                None
+            } else {
+                Some(&*(ptr as *mut #name))
+            }
+        }
+    } else {
+        quote! {
+            assert!(!ptr.is_null());
+            Some(&*(ptr as *mut #name))
+        }
+    }
+}
+
+fn gen_impl_from_value(name: &Ident) -> TokenStream {
+    quote! {
+        impl<'a> glib::value::FromValue<'a> for &'a #name {
+            unsafe fn from_value(value: &'a glib::value::Value) -> Self {
+                let ptr = glib::gobject_sys::g_value_get_boxed(
+                    glib::translate::ToGlibPtr::to_glib_none(value).0,
+                );
+                assert!(!ptr.is_null());
+                &*(ptr as *mut #name)
+            }
+        }
+    }
+}
 
 pub fn impl_gboxed(input: &syn::DeriveInput) -> TokenStream {
     let name = &input.ident;
@@ -17,6 +63,19 @@ pub fn impl_gboxed(input: &syn::DeriveInput) -> TokenStream {
             "{}: derive(GBoxed) requires #[gboxed(type_name = \"BoxedTypeName\")]",
             e
         ),
+    };
+
+    let meta = find_attribute_meta(&input.attrs, "gboxed")
+        .unwrap()
+        .unwrap();
+    let nullable = find_nested_meta(&meta, "nullable").is_some();
+
+    let option_to_ptr = gen_option_to_ptr(nullable);
+    let ptr_to_option = gen_ptr_to_option(name, nullable);
+    let impl_from_value = if !nullable {
+        gen_impl_from_value(name)
+    } else {
+        quote! {}
     };
 
     quote! {
@@ -56,8 +115,7 @@ pub fn impl_gboxed(input: &syn::DeriveInput) -> TokenStream {
 
         impl glib::value::SetValueOptional for #name {
             unsafe fn set_value_optional(value: &mut glib::value::Value, this: Option<&Self>) {
-                let this = this.expect("None not allowed");
-                let ptr: *mut #name = Box::into_raw(Box::new(this.clone()));
+                let ptr: *mut #name = #option_to_ptr;
                 glib::gobject_sys::g_value_take_boxed(
                     glib::translate::ToGlibPtrMut::to_glib_none_mut(value).0,
                     ptr as *mut _,
@@ -70,20 +128,10 @@ pub fn impl_gboxed(input: &syn::DeriveInput) -> TokenStream {
                 let ptr = glib::gobject_sys::g_value_get_boxed(
                     glib::translate::ToGlibPtr::to_glib_none(value).0,
                 );
-                assert!(!ptr.is_null());
-                Some(&*(ptr as *mut #name))
+                #ptr_to_option
             }
         }
 
-        impl<'a> glib::value::FromValue<'a> for &'a #name {
-            unsafe fn from_value(value: &'a glib::value::Value) -> Self {
-                let ptr = glib::gobject_sys::g_value_get_boxed(
-                    glib::translate::ToGlibPtr::to_glib_none(value).0,
-                );
-                assert!(!ptr.is_null());
-                &*(ptr as *mut #name)
-            }
-        }
-
+        #impl_from_value
     }
 }

--- a/glib-macros/src/gboxed_derive.rs
+++ b/glib-macros/src/gboxed_derive.rs
@@ -42,10 +42,10 @@ fn gen_ptr_to_option(name: &Ident, nullable: bool) -> TokenStream {
 
 fn gen_impl_from_value(name: &Ident) -> TokenStream {
     quote! {
-        impl<'a> glib::value::FromValue<'a> for &'a #name {
-            unsafe fn from_value(value: &'a glib::value::Value) -> Self {
-                let ptr = glib::gobject_sys::g_value_get_boxed(
-                    glib::translate::ToGlibPtr::to_glib_none(value).0,
+        impl<'a> ::glib::value::FromValue<'a> for &'a #name {
+            unsafe fn from_value(value: &'a ::glib::value::Value) -> Self {
+                let ptr = ::glib::gobject_sys::g_value_get_boxed(
+                    ::glib::translate::ToGlibPtr::to_glib_none(value).0,
                 );
                 assert!(!ptr.is_null());
                 &*(ptr as *mut #name)
@@ -82,12 +82,12 @@ pub fn impl_gboxed(input: &syn::DeriveInput) -> TokenStream {
         impl BoxedType for #name {
             const NAME: &'static str = #gtype_name;
 
-            fn get_type() -> glib::Type {
-                static mut TYPE_: glib::Type = glib::Type::Invalid;
+            fn get_type() -> ::glib::Type {
+                static mut TYPE_: ::glib::Type = ::glib::Type::Invalid;
                 static ONCE: ::std::sync::Once = ::std::sync::Once::new();
 
                 ONCE.call_once(|| {
-                    let type_ = glib::subclass::register_boxed_type::<Self>();
+                    let type_ = ::glib::subclass::register_boxed_type::<Self>();
                     unsafe {
                         TYPE_ = type_;
                     }
@@ -97,36 +97,36 @@ pub fn impl_gboxed(input: &syn::DeriveInput) -> TokenStream {
             }
         }
 
-        impl glib::StaticType for #name {
-            fn static_type() -> glib::Type {
-                <#name as glib::subclass::boxed::BoxedType>::get_type()
+        impl ::glib::StaticType for #name {
+            fn static_type() -> ::glib::Type {
+                <#name as ::glib::subclass::boxed::BoxedType>::get_type()
             }
         }
 
-        impl glib::value::SetValue for #name {
-            unsafe fn set_value(value: &mut glib::value::Value, this: &Self) {
+        impl ::glib::value::SetValue for #name {
+            unsafe fn set_value(value: &mut ::glib::value::Value, this: &Self) {
                 let ptr: *mut #name = Box::into_raw(Box::new(this.clone()));
-                glib::gobject_sys::g_value_take_boxed(
-                    glib::translate::ToGlibPtrMut::to_glib_none_mut(value).0,
+                ::glib::gobject_sys::g_value_take_boxed(
+                    ::glib::translate::ToGlibPtrMut::to_glib_none_mut(value).0,
                     ptr as *mut _,
                 );
             }
         }
 
-        impl glib::value::SetValueOptional for #name {
-            unsafe fn set_value_optional(value: &mut glib::value::Value, this: Option<&Self>) {
+        impl ::glib::value::SetValueOptional for #name {
+            unsafe fn set_value_optional(value: &mut ::glib::value::Value, this: Option<&Self>) {
                 let ptr: *mut #name = #option_to_ptr;
-                glib::gobject_sys::g_value_take_boxed(
-                    glib::translate::ToGlibPtrMut::to_glib_none_mut(value).0,
+                ::glib::gobject_sys::g_value_take_boxed(
+                    ::glib::translate::ToGlibPtrMut::to_glib_none_mut(value).0,
                     ptr as *mut _,
                 );
             }
         }
 
-        impl<'a> glib::value::FromValueOptional<'a> for &'a #name {
-            unsafe fn from_value_optional(value: &'a glib::value::Value) -> Option<Self> {
-                let ptr = glib::gobject_sys::g_value_get_boxed(
-                    glib::translate::ToGlibPtr::to_glib_none(value).0,
+        impl<'a> ::glib::value::FromValueOptional<'a> for &'a #name {
+            unsafe fn from_value_optional(value: &'a ::glib::value::Value) -> Option<Self> {
+                let ptr = ::glib::gobject_sys::g_value_get_boxed(
+                    ::glib::translate::ToGlibPtr::to_glib_none(value).0,
                 );
                 #ptr_to_option
             }

--- a/glib-macros/src/genum_derive.rs
+++ b/glib-macros/src/genum_derive.rs
@@ -1,3 +1,7 @@
+// Copyright 2020, The Gtk-rs Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
 use anyhow::{bail, Result};
 use heck::{CamelCase, KebabCase, SnakeCase};
 use itertools::Itertools;

--- a/glib-macros/src/genum_derive.rs
+++ b/glib-macros/src/genum_derive.rs
@@ -151,44 +151,44 @@ pub fn impl_genum(input: &syn::DeriveInput) -> TokenStream {
             }
         }
 
-        impl glib::translate::FromGlib<i32> for #name {
+        impl ::glib::translate::FromGlib<i32> for #name {
             fn from_glib(value: i32) -> Self {
                 #from_glib
                 unreachable!();
             }
         }
 
-        impl<'a> glib::value::FromValueOptional<'a> for #name {
-            unsafe fn from_value_optional(value: &glib::Value) -> Option<Self> {
-                Some(glib::value::FromValue::from_value(value))
+        impl<'a> ::glib::value::FromValueOptional<'a> for #name {
+            unsafe fn from_value_optional(value: &::glib::Value) -> Option<Self> {
+                Some(::glib::value::FromValue::from_value(value))
             }
         }
 
-        impl<'a> glib::value::FromValue<'a> for #name {
-            unsafe fn from_value(value: &glib::Value) -> Self {
-                glib::translate::from_glib(
+        impl<'a> ::glib::value::FromValue<'a> for #name {
+            unsafe fn from_value(value: &::glib::Value) -> Self {
+                ::glib::translate::from_glib(
                     gobject_sys::g_value_get_enum(
-                        glib::translate::ToGlibPtr::to_glib_none(value).0))
+                        ::glib::translate::ToGlibPtr::to_glib_none(value).0))
             }
         }
 
-        impl glib::value::SetValue for #name {
-            unsafe fn set_value(value: &mut glib::Value, this: &Self) {
+        impl ::glib::value::SetValue for #name {
+            unsafe fn set_value(value: &mut ::glib::Value, this: &Self) {
                 gobject_sys::g_value_set_enum(
-                    glib::translate::ToGlibPtrMut::to_glib_none_mut(value).0,
-                    glib::translate::ToGlib::to_glib(this))
+                    ::glib::translate::ToGlibPtrMut::to_glib_none_mut(value).0,
+                    ::glib::translate::ToGlib::to_glib(this))
             }
         }
 
         impl StaticType for #name {
-            fn static_type() -> glib::Type {
+            fn static_type() -> ::glib::Type {
                 #get_type()
             }
         }
 
-        fn #get_type() -> glib::Type {
+        fn #get_type() -> ::glib::Type {
             static ONCE: std::sync::Once = std::sync::Once::new();
-            static mut TYPE: glib::Type = glib::Type::Invalid;
+            static mut TYPE: ::glib::Type = ::glib::Type::Invalid;
 
             ONCE.call_once(|| {
                 static mut VALUES: [gobject_sys::GEnumValue; #nb_genum_values] = [
@@ -203,12 +203,12 @@ pub fn impl_genum(input: &syn::DeriveInput) -> TokenStream {
                 let name = std::ffi::CString::new(#gtype_name).expect("CString::new failed");
                 unsafe {
                     let type_ = gobject_sys::g_enum_register_static(name.as_ptr(), VALUES.as_ptr());
-                    TYPE = glib::translate::from_glib(type_);
+                    TYPE = ::glib::translate::from_glib(type_);
                 }
             });
 
             unsafe {
-                assert_ne!(TYPE, glib::Type::Invalid);
+                assert_ne!(TYPE, ::glib::Type::Invalid);
                 TYPE
             }
         }

--- a/glib-macros/src/genum_derive.rs
+++ b/glib-macros/src/genum_derive.rs
@@ -13,7 +13,7 @@ use syn::{
     Variant,
 };
 
-use crate::utils::{find_genum_meta, parse_attribute, parse_type_name};
+use crate::utils::{find_attribute_meta, parse_attribute, parse_type_name};
 
 // Generate i32 to enum mapping, used to implement glib::translate::FromGlib<i32>, such as:
 //   if value == Animal::Goat as i32 {
@@ -53,7 +53,7 @@ fn parse_item_attribute(meta: &NestedMeta) -> Result<ItemAttribute> {
 // Parse optional enum item attributes such as:
 // #[genum(name = "My Name", nick = "my-nick")]
 fn parse_item_attributes(attrs: &[Attribute]) -> Result<Vec<ItemAttribute>> {
-    let meta = find_genum_meta(attrs)?;
+    let meta = find_attribute_meta(attrs, "genum")?;
 
     let v = match meta {
         Some(meta) => meta
@@ -131,7 +131,7 @@ pub fn impl_genum(input: &syn::DeriveInput) -> TokenStream {
         _ => abort_call_site!("GEnum only supports enums"),
     };
 
-    let gtype_name = match parse_type_name(&input) {
+    let gtype_name = match parse_type_name(&input, "genum") {
         Ok(v) => v,
         Err(e) => abort_call_site!(
             "{}: derive(GEnum) requires #[genum(type_name = \"EnumTypeName\")]",

--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -4,6 +4,7 @@
 
 extern crate proc_macro;
 
+mod gboxed_derive;
 mod genum_derive;
 mod utils;
 
@@ -15,5 +16,30 @@ use syn::{parse_macro_input, DeriveInput};
 pub fn genum_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let gen = genum_derive::impl_genum(&input);
+    gen.into()
+}
+
+/// Derive macro for defining a [`BoxedType`]`::get_type` function and
+/// the [`glib::Value`] traits.
+///
+/// # Example
+///
+/// ```
+/// #[macro_use] extern crate glib;
+/// use glib::prelude::*;
+/// use glib::subclass::prelude::*;
+///
+/// #[derive(Clone, Debug, PartialEq, Eq, GBoxed)]
+/// #[gboxed(type_name = "MyBoxed")]
+/// struct MyBoxed(String);
+/// ```
+///
+/// [`BoxedType`]: subclass/boxed/trait.BoxedType.html
+/// [`glib::Value`]: value/struct.Value.html
+#[proc_macro_derive(GBoxed, attributes(gboxed))]
+#[proc_macro_error]
+pub fn gboxed_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let gen = gboxed_derive::impl_gboxed(&input);
     gen.into()
 }

--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -5,6 +5,7 @@
 extern crate proc_macro;
 
 mod genum_derive;
+mod utils;
 
 use proc_macro_error::proc_macro_error;
 use syn::{parse_macro_input, DeriveInput};

--- a/glib-macros/src/utils.rs
+++ b/glib-macros/src/utils.rs
@@ -1,0 +1,73 @@
+// Copyright 2020, The Gtk-rs Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+use anyhow::{bail, Result};
+use syn::{Attribute, DeriveInput, Lit, Meta, MetaList, NestedMeta};
+
+// find the #[genum] attribute in @attrs
+pub fn find_genum_meta(attrs: &[Attribute]) -> Result<Option<MetaList>> {
+    let meta = match attrs.iter().find(|a| a.path.is_ident("genum")) {
+        Some(a) => a.parse_meta(),
+        _ => return Ok(None),
+    };
+    match meta? {
+        Meta::List(n) => Ok(Some(n)),
+        _ => bail!("wrong meta type"),
+    }
+}
+
+// parse a single meta like: ident = "value"
+pub fn parse_attribute(meta: &NestedMeta) -> Result<(String, String)> {
+    let meta = match &meta {
+        NestedMeta::Meta(m) => m,
+        _ => bail!("wrong meta type"),
+    };
+    let meta = match meta {
+        Meta::NameValue(n) => n,
+        _ => bail!("wrong meta type"),
+    };
+    let value = match &meta.lit {
+        Lit::Str(s) => s.value(),
+        _ => bail!("wrong meta type"),
+    };
+
+    let ident = match meta.path.get_ident() {
+        None => bail!("missing ident"),
+        Some(ident) => ident,
+    };
+
+    Ok((ident.to_string(), value))
+}
+
+#[derive(Debug)]
+pub enum EnumAttribute {
+    TypeName(String),
+}
+
+pub fn parse_enum_attribute(meta: &NestedMeta) -> Result<EnumAttribute> {
+    let (ident, v) = parse_attribute(meta)?;
+
+    match ident.as_ref() {
+        "type_name" => Ok(EnumAttribute::TypeName(v)),
+        s => bail!("Unknown enum meta {}", s),
+    }
+}
+
+// Parse enum attribute such as:
+// #[genum(type_name = "TestAnimalType")]
+pub fn parse_type_name(input: &DeriveInput) -> Result<String> {
+    let meta = match find_genum_meta(&input.attrs)? {
+        Some(meta) => meta,
+        _ => bail!("Missing 'genum' attribute"),
+    };
+
+    let meta = match meta.nested.first() {
+        Some(meta) => meta,
+        _ => bail!("Missing meta 'type_name'"),
+    };
+
+    match parse_enum_attribute(&meta)? {
+        EnumAttribute::TypeName(n) => Ok(n),
+    }
+}

--- a/glib-macros/src/utils.rs
+++ b/glib-macros/src/utils.rs
@@ -54,6 +54,13 @@ pub fn parse_enum_attribute(meta: &NestedMeta) -> Result<EnumAttribute> {
     }
 }
 
+fn find_nested_meta<'a>(meta: &'a MetaList, name: &str) -> Option<&'a NestedMeta> {
+    meta.nested.iter().find(|n| match n {
+        NestedMeta::Meta(m) => m.path().is_ident(name),
+        _ => false,
+    })
+}
+
 // Parse attribute such as:
 // #[genum(type_name = "TestAnimalType")]
 pub fn parse_type_name(input: &DeriveInput, attr_name: &str) -> Result<String> {
@@ -62,7 +69,7 @@ pub fn parse_type_name(input: &DeriveInput, attr_name: &str) -> Result<String> {
         _ => bail!("Missing '{}' attribute", attr_name),
     };
 
-    let meta = match meta.nested.first() {
+    let meta = match find_nested_meta(&meta, "type_name") {
         Some(meta) => meta,
         _ => bail!("Missing meta 'type_name'"),
     };

--- a/glib-macros/src/utils.rs
+++ b/glib-macros/src/utils.rs
@@ -5,9 +5,9 @@
 use anyhow::{bail, Result};
 use syn::{Attribute, DeriveInput, Lit, Meta, MetaList, NestedMeta};
 
-// find the #[genum] attribute in @attrs
-pub fn find_genum_meta(attrs: &[Attribute]) -> Result<Option<MetaList>> {
-    let meta = match attrs.iter().find(|a| a.path.is_ident("genum")) {
+// find the #[@attr_name] attribute in @attrs
+pub fn find_attribute_meta(attrs: &[Attribute], attr_name: &str) -> Result<Option<MetaList>> {
+    let meta = match attrs.iter().find(|a| a.path.is_ident(attr_name)) {
         Some(a) => a.parse_meta(),
         _ => return Ok(None),
     };
@@ -54,12 +54,12 @@ pub fn parse_enum_attribute(meta: &NestedMeta) -> Result<EnumAttribute> {
     }
 }
 
-// Parse enum attribute such as:
+// Parse attribute such as:
 // #[genum(type_name = "TestAnimalType")]
-pub fn parse_type_name(input: &DeriveInput) -> Result<String> {
-    let meta = match find_genum_meta(&input.attrs)? {
+pub fn parse_type_name(input: &DeriveInput, attr_name: &str) -> Result<String> {
+    let meta = match find_attribute_meta(&input.attrs, attr_name)? {
         Some(meta) => meta,
-        _ => bail!("Missing 'genum' attribute"),
+        _ => bail!("Missing '{}' attribute", attr_name),
     };
 
     let meta = match meta.nested.first() {

--- a/glib-macros/src/utils.rs
+++ b/glib-macros/src/utils.rs
@@ -54,7 +54,7 @@ pub fn parse_enum_attribute(meta: &NestedMeta) -> Result<EnumAttribute> {
     }
 }
 
-fn find_nested_meta<'a>(meta: &'a MetaList, name: &str) -> Option<&'a NestedMeta> {
+pub fn find_nested_meta<'a>(meta: &'a MetaList, name: &str) -> Option<&'a NestedMeta> {
     meta.nested.iter().find(|n| match n {
         NestedMeta::Meta(m) => m.path().is_ident(name),
         _ => false,

--- a/glib-macros/tests/test.rs
+++ b/glib-macros/tests/test.rs
@@ -82,3 +82,25 @@ fn derive_gboxed() {
     let result = std::panic::catch_unwind(|| b.to_value());
     assert!(result.is_err());
 }
+
+#[test]
+fn derive_gboxed_nullable() {
+    #[derive(Clone, Debug, PartialEq, Eq, GBoxed)]
+    #[gboxed(type_name = "MyNullableBoxed", nullable)]
+    struct MyNullableBoxed(String);
+
+    assert_eq!(MyNullableBoxed::get_type().name(), "MyNullableBoxed");
+
+    let b = MyNullableBoxed(String::from("abc"));
+    let v = b.to_value();
+    assert_eq!(&b, v.get::<&MyNullableBoxed>().unwrap().unwrap());
+
+    let b = Some(MyNullableBoxed(String::from("def")));
+    let v = b.to_value();
+    let b = b.unwrap();
+    assert_eq!(&b, v.get::<&MyNullableBoxed>().unwrap().unwrap());
+
+    let b: Option<MyNullableBoxed> = None;
+    let v = b.to_value();
+    assert_eq!(None, v.get::<&MyNullableBoxed>().unwrap());
+}

--- a/glib-macros/tests/test.rs
+++ b/glib-macros/tests/test.rs
@@ -6,8 +6,6 @@ use ::glib_macros::{GBoxed, GEnum};
 use glib::prelude::*;
 use glib::subclass::prelude::*;
 use glib::translate::{FromGlib, ToGlib};
-#[macro_use]
-extern crate glib;
 
 #[test]
 fn derive_genum() {

--- a/glib-macros/tests/test.rs
+++ b/glib-macros/tests/test.rs
@@ -2,9 +2,12 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
-use ::glib_macros::GEnum;
+use ::glib_macros::{GBoxed, GEnum};
 use glib::prelude::*;
+use glib::subclass::prelude::*;
 use glib::translate::{FromGlib, ToGlib};
+#[macro_use]
+extern crate glib;
 
 #[test]
 fn derive_genum() {
@@ -56,4 +59,28 @@ fn derive_genum() {
     assert_eq!(v.get_name(), "The Cat");
     assert_eq!(v.get_nick(), "chat");
     assert_eq!(e.get_value(2), None);
+}
+
+#[test]
+fn derive_gboxed() {
+    #[derive(Clone, Debug, PartialEq, Eq, GBoxed)]
+    #[gboxed(type_name = "MyBoxed")]
+    struct MyBoxed(String);
+
+    assert_eq!(MyBoxed::get_type().name(), "MyBoxed");
+
+    let b = MyBoxed(String::from("abc"));
+    let v = b.to_value();
+    assert_eq!(&b, v.get::<&MyBoxed>().unwrap().unwrap());
+    assert_eq!(&b, v.get_some::<&MyBoxed>().unwrap());
+
+    let b = Some(MyBoxed(String::from("def")));
+    let v = b.to_value();
+    let b = b.unwrap();
+    assert_eq!(&b, v.get::<&MyBoxed>().unwrap().unwrap());
+    assert_eq!(&b, v.get_some::<&MyBoxed>().unwrap());
+
+    let b: Option<MyBoxed> = None;
+    let result = std::panic::catch_unwind(|| b.to_value());
+    assert!(result.is_err());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub extern crate glib_sys;
 pub extern crate gobject_sys;
 
 extern crate glib_macros;
-pub use glib_macros::GEnum;
+pub use glib_macros::{GBoxed, GEnum};
 
 extern crate futures_channel;
 extern crate futures_core;

--- a/src/subclass/boxed.rs
+++ b/src/subclass/boxed.rs
@@ -26,9 +26,9 @@ pub trait BoxedType: Clone + Sized + 'static {
 
     /// Returns the type ID.
     ///
-    /// This is usually defined via the [`glib_boxed_type!`] macro.
+    /// This is usually defined via the [`GBoxed!`] derive macro.
     ///
-    /// [`glib_boxed_type!`]: ../../macro.glib_boxed_type.html
+    /// [`GBoxed!`]: ../../derive.GBoxed.html
     fn get_type() -> ::Type;
 }
 
@@ -36,10 +36,10 @@ pub trait BoxedType: Clone + Sized + 'static {
 ///
 /// This must be called only once and will panic on a second call.
 ///
-/// See [`glib_boxed_type!`] for defining a function that ensures that
+/// See [`GBoxed!`] for defining a function that ensures that
 /// this is only called once and returns the type id.
 ///
-/// [`glib_boxed_type!`]: ../../macro.glib_boxed_type.html
+/// [`GBoxed!`]: ../../derive.GBoxed.html
 pub fn register_boxed_type<T: BoxedType>() -> ::Type {
     unsafe extern "C" fn boxed_copy<T: BoxedType>(v: glib_sys::gpointer) -> glib_sys::gpointer {
         let v = &*(v as *mut T);
@@ -152,10 +152,10 @@ macro_rules! glib_boxed_derive_traits {
 
 /// Wrapper struct for storing any `BoxedType` in `glib::Value`.
 ///
-/// Instead of this the [`glib_boxed_derive_traits!`] macro can be used to
+/// Instead of this the [`GBoxed!`] derive macro can be used to
 /// directly implement the relevant traits on the type itself.
 ///
-/// [`glib_boxed_derive_traits!`]: ../../macro.glib_boxed_derive_traits.html
+/// [`GBoxed!`]: ../../derive.GBoxed.html
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Boxed<T: BoxedType>(pub T);
 

--- a/src/subclass/boxed.rs
+++ b/src/subclass/boxed.rs
@@ -70,86 +70,6 @@ pub fn register_boxed_type<T: BoxedType>() -> ::Type {
     }
 }
 
-#[macro_export]
-/// Macro for defining a `get_type` function.
-///
-/// This returns a `glib::Type` and registers `Self` via [`register_boxed_type`]
-/// the first time it is called.
-///
-/// [`register_boxed_type`]: subclass/boxed/fn.register_boxed_type.html
-macro_rules! glib_boxed_type {
-    () => {
-        fn get_type() -> $crate::Type {
-            static mut TYPE_: $crate::Type = $crate::Type::Invalid;
-            static ONCE: ::std::sync::Once = ::std::sync::Once::new();
-
-            ONCE.call_once(|| {
-                let type_ = $crate::subclass::register_boxed_type::<Self>();
-                unsafe {
-                    TYPE_ = type_;
-                }
-            });
-
-            unsafe { TYPE_ }
-        }
-    };
-}
-
-#[macro_export]
-/// Macro for deriving the `glib::Value` traits for a [`BoxedType`].
-///
-/// [`BoxedType`]: trait.BoxedType.html
-macro_rules! glib_boxed_derive_traits {
-    ($name:ident) => {
-        impl $crate::StaticType for $name {
-            fn static_type() -> $crate::Type {
-                <$name as $crate::subclass::boxed::BoxedType>::get_type()
-            }
-        }
-
-        impl $crate::value::SetValue for $name {
-            unsafe fn set_value(value: &mut $crate::value::Value, this: &Self) {
-                let ptr: *mut $name = Box::into_raw(Box::new(this.clone()));
-                $crate::gobject_sys::g_value_take_boxed(
-                    $crate::translate::ToGlibPtrMut::to_glib_none_mut(value).0,
-                    ptr as *mut _,
-                );
-            }
-        }
-
-        impl $crate::value::SetValueOptional for $name {
-            unsafe fn set_value_optional(value: &mut $crate::value::Value, this: Option<&Self>) {
-                let this = this.expect("None not allowed");
-                let ptr: *mut $name = Box::into_raw(Box::new(this.clone()));
-                $crate::gobject_sys::g_value_take_boxed(
-                    $crate::translate::ToGlibPtrMut::to_glib_none_mut(value).0,
-                    ptr as *mut _,
-                );
-            }
-        }
-
-        impl<'a> $crate::value::FromValueOptional<'a> for &'a $name {
-            unsafe fn from_value_optional(value: &'a $crate::value::Value) -> Option<Self> {
-                let ptr = $crate::gobject_sys::g_value_get_boxed(
-                    $crate::translate::ToGlibPtr::to_glib_none(value).0,
-                );
-                assert!(!ptr.is_null());
-                Some(&*(ptr as *mut $name))
-            }
-        }
-
-        impl<'a> $crate::value::FromValue<'a> for &'a $name {
-            unsafe fn from_value(value: &'a $crate::value::Value) -> Self {
-                let ptr = $crate::gobject_sys::g_value_get_boxed(
-                    $crate::translate::ToGlibPtr::to_glib_none(value).0,
-                );
-                assert!(!ptr.is_null());
-                &*(ptr as *mut $name)
-            }
-        }
-    };
-}
-
 /// Wrapper struct for storing any `BoxedType` in `glib::Value`.
 ///
 /// Instead of this the [`GBoxed!`] derive macro can be used to
@@ -213,17 +133,12 @@ impl<'a, T: BoxedType> FromValue<'a> for &'a Boxed<T> {
 #[cfg(test)]
 mod test {
     use super::*;
+    // GBoxed macro assumes 'glib' is in scope
+    use crate as glib;
 
-    #[derive(Clone, Debug, PartialEq, Eq)]
+    #[derive(Clone, Debug, PartialEq, Eq, glib::GBoxed)]
+    #[gboxed(type_name = "MyBoxed")]
     struct MyBoxed(String);
-
-    impl BoxedType for MyBoxed {
-        const NAME: &'static str = "MyBoxed";
-
-        glib_boxed_type!();
-    }
-
-    glib_boxed_derive_traits!(MyBoxed);
 
     #[test]
     fn test_register() {

--- a/src/subclass/mod.rs
+++ b/src/subclass/mod.rs
@@ -186,21 +186,9 @@
 //! use glib::subclass;
 //! use glib::subclass::prelude::*;
 //!
-//! #[derive(Clone, Debug, PartialEq, Eq)]
+//! #[derive(Clone, Debug, PartialEq, Eq, GBoxed)]
+//! #[gboxed(type_name = "MyBoxed")]
 //! struct MyBoxed(String);
-//!
-//! impl BoxedType for MyBoxed {
-//!     // This type name must be unique per process.
-//!     const NAME: &'static str = "MyBoxed";
-//!
-//!     // This macro defines a
-//!     //   fn get_type() -> glib::Type
-//!     // function
-//!     glib_boxed_type!();
-//! }
-//!
-//! // This macro derives some traits on the struct
-//! glib_boxed_derive_traits!(MyBoxed);
 //!
 //! pub fn main() {
 //!     assert_ne!(glib::Type::Invalid, MyBoxed::get_type());


### PR DESCRIPTION
Is there any reason to keep `glib_boxed_type!` and `glib_boxed_derive_traits!` or should I just in-lined them in the Derive macro?