### PR TITLE
Use mem::ManuallyDrop instead of mem::forget() everywhere

### DIFF
--- a/src/byte_array.rs
+++ b/src/byte_array.rs
@@ -48,10 +48,10 @@ impl ByteArray {
 
     pub fn into_gbytes(self) -> Bytes {
         unsafe {
+            let s = mem::ManuallyDrop::new(self);
             let ret = from_glib_full(glib_sys::g_byte_array_free_to_bytes(mut_override(
-                self.to_glib_none().0,
+                s.to_glib_none().0,
             )));
-            mem::forget(self);
             ret
         }
     }

--- a/src/subclass/object.rs
+++ b/src/subclass/object.rs
@@ -85,8 +85,8 @@ unsafe extern "C" fn get_property<T: ObjectSubclass>(
             // a copy of the value when setting it on the destination just to
             // immediately free the original value afterwards.
             gobject_sys::g_value_unset(value);
+            let v = mem::ManuallyDrop::new(v);
             ptr::write(value, ptr::read(v.to_glib_none().0));
-            mem::forget(v);
         }
         Err(()) => eprintln!("Failed to get property"),
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -269,8 +269,8 @@ impl Value {
     #[doc(hidden)]
     pub fn into_raw(self) -> gobject_sys::GValue {
         unsafe {
-            let ret = ptr::read(&self.0);
-            mem::forget(self);
+            let s = mem::ManuallyDrop::new(self);
+            let ret = ptr::read(&s.0);
             ret
         }
     }


### PR DESCRIPTION
It makes the intentions clearer and potentially results in simpler
assembly, at least in debug builds.