### PR TITLE
Remove unnecessary transmute calls

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -343,7 +343,7 @@ pub trait Cast: ObjectType {
         if !self.is::<T>() {
             None
         } else {
-            // This transmute is safe because all our wrapper types have the
+            // This cast is safe because all our wrapper types have the
             // same representation except for the name and the phantom data
             // type. IsA<> is an unsafe trait that must only be implemented
             // if this is a valid wrapper type
@@ -364,7 +364,7 @@ pub trait Cast: ObjectType {
     /// Panics if compiled with `debug_assertions` and the instance doesn't implement `T`.
     unsafe fn unsafe_cast_ref<T: ObjectType>(&self) -> &T {
         debug_assert!(self.is::<T>());
-        // This transmute is safe because all our wrapper types have the
+        // This cast is safe because all our wrapper types have the
         // same representation except for the name and the phantom data
         // type. IsA<> is an unsafe trait that must only be implemented
         // if this is a valid wrapper type
@@ -1541,7 +1541,7 @@ impl<T: ObjectType> ObjectExt for T {
         ::signal::connect_raw(
             self.as_object_ref().to_glib_none().0,
             signal_name.as_ptr() as *const _,
-            Some(mem::transmute(notify_trampoline::<Self, F> as usize)),
+            Some(*(&notify_trampoline::<Self, F> as *const _ as *const _)),
             Box::into_raw(f),
         )
     }

--- a/src/source.rs
+++ b/src/source.rs
@@ -6,7 +6,6 @@ use glib_sys::{self, gboolean, gpointer};
 #[cfg(all(not(unix), feature = "dox"))]
 use libc::c_int as RawFd;
 use std::cell::RefCell;
-use std::mem::transmute;
 use std::num::NonZeroU32;
 #[cfg(unix)]
 use std::os::unix::io::RawFd;
@@ -311,7 +310,7 @@ where
         from_glib(glib_sys::g_child_watch_add_full(
             glib_sys::G_PRIORITY_DEFAULT,
             pid.0,
-            Some(transmute(trampoline_child_watch::<F> as usize)),
+            Some(trampoline_child_watch::<F>),
             into_raw_child_watch(func),
             Some(destroy_closure_child_watch::<F>),
         ))
@@ -337,7 +336,7 @@ where
         from_glib(glib_sys::g_child_watch_add_full(
             glib_sys::G_PRIORITY_DEFAULT,
             pid.0,
-            Some(transmute(trampoline_child_watch::<F> as usize)),
+            Some(trampoline_child_watch::<F>),
             into_raw_child_watch(func),
             Some(destroy_closure_child_watch::<F>),
         ))
@@ -415,7 +414,7 @@ where
             glib_sys::G_PRIORITY_DEFAULT,
             fd,
             condition.to_glib(),
-            Some(transmute(trampoline_unix_fd::<F> as usize)),
+            Some(trampoline_unix_fd::<F>),
             into_raw_unix_fd(func),
             Some(destroy_closure_unix_fd::<F>),
         ))
@@ -447,7 +446,7 @@ where
             glib_sys::G_PRIORITY_DEFAULT,
             fd,
             condition.to_glib(),
-            Some(transmute(trampoline_unix_fd::<F> as usize)),
+            Some(trampoline_unix_fd::<F>),
             into_raw_unix_fd(func),
             Some(destroy_closure_unix_fd::<F>),
         ))
@@ -612,7 +611,7 @@ where
         let source = glib_sys::g_child_watch_source_new(pid.0);
         glib_sys::g_source_set_callback(
             source,
-            Some(transmute(trampoline_child_watch::<F> as usize)),
+            Some(*(&trampoline_child_watch::<F> as *const _ as *const _)),
             into_raw_child_watch(func),
             Some(destroy_closure_child_watch::<F>),
         );
@@ -679,7 +678,7 @@ where
         let source = glib_sys::g_unix_fd_source_new(fd, condition.to_glib());
         glib_sys::g_source_set_callback(
             source,
-            Some(transmute(trampoline_unix_fd::<F> as usize)),
+            Some(*(&trampoline_unix_fd::<F> as *const _ as *const _)),
             into_raw_unix_fd(func),
             Some(destroy_closure_unix_fd::<F>),
         );

--- a/src/value.rs
+++ b/src/value.rs
@@ -183,7 +183,7 @@ impl Value {
                 T::static_type().to_glib(),
             ));
             if ok {
-                // This transmute is safe because Value and TypedValue have the same
+                // This cast is safe because Value and TypedValue have the same
                 // representation: the only difference is the zero-sized phantom data
                 Some(&*(self as *const Value as *const TypedValue<T>))
             } else {
@@ -800,7 +800,7 @@ impl SendValue {
                 T::static_type().to_glib(),
             ));
             if ok {
-                // This transmute is safe because SendValue and TypedValue have the same
+                // This cast is safe because SendValue and TypedValue have the same
                 // representation: the only difference is the zero-sized phantom data
                 Some(&*(self as *const SendValue as *const TypedValue<T>))
             } else {


### PR DESCRIPTION
I removed some `transmute` calls and added comments where they were missing.

cc @sdroege @EPashkin 