### PR TITLE
Remove deprecated Error::description impl

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -92,12 +92,6 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        self.message()
-    }
-}
-
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Error")
@@ -107,6 +101,8 @@ impl fmt::Debug for Error {
             .finish()
     }
 }
+
+impl error::Error for Error {}
 
 /// `GLib` error domain.
 ///
@@ -204,19 +200,11 @@ impl BoolError {
 
 impl fmt::Display for BoolError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "Error {:?} in {:?} at {}:{}",
-            self.message, self.function, self.filename, self.line
-        )
+        f.write_str(&self.message)
     }
 }
 
-impl error::Error for BoolError {
-    fn description(&self) -> &str {
-        self.message.as_ref()
-    }
-}
+impl error::Error for BoolError {}
 
 #[cfg(test)]
 mod tests {
@@ -224,18 +212,16 @@ mod tests {
 
     #[test]
     fn test_bool_error() {
-        use std::error::Error;
-
         let from_static_msg = glib_bool_error!("Static message");
-        assert_eq!(from_static_msg.description(), "Static message");
+        assert_eq!(from_static_msg.to_string(), "Static message");
 
         let from_dynamic_msg = glib_bool_error!("{} message", "Dynamic");
-        assert_eq!(from_dynamic_msg.description(), "Dynamic message");
+        assert_eq!(from_dynamic_msg.to_string(), "Dynamic message");
 
         let false_static_res = glib_result_from_gboolean!(glib_sys::GFALSE, "Static message");
         assert!(false_static_res.is_err());
         let static_err = false_static_res.err().unwrap();
-        assert_eq!(static_err.description(), "Static message");
+        assert_eq!(static_err.to_string(), "Static message");
 
         let true_static_res = glib_result_from_gboolean!(glib_sys::GTRUE, "Static message");
         assert!(true_static_res.is_ok());
@@ -244,7 +230,7 @@ mod tests {
             glib_result_from_gboolean!(glib_sys::GFALSE, "{} message", "Dynamic");
         assert!(false_dynamic_res.is_err());
         let dynamic_err = false_dynamic_res.err().unwrap();
-        assert_eq!(dynamic_err.description(), "Dynamic message");
+        assert_eq!(dynamic_err.to_string(), "Dynamic message");
 
         let true_dynamic_res = glib_result_from_gboolean!(glib_sys::GTRUE, "{} message", "Dynamic");
         assert!(true_dynamic_res.is_ok());

--- a/src/subclass/object.rs
+++ b/src/subclass/object.rs
@@ -346,7 +346,7 @@ mod test {
     use super::*;
     use prelude::*;
 
-    use std::{cell::RefCell, error::Error};
+    use std::cell::RefCell;
 
     // A dummy `Object` to test setting an `Object` property and returning an `Object` in signals
     pub struct ChildObject;
@@ -606,7 +606,7 @@ mod test {
             obj.set_property("test", &true)
                 .err()
                 .expect("set_property failed")
-                .description(),
+                .to_string(),
             "property not found",
         );
 
@@ -614,7 +614,7 @@ mod test {
             obj.set_property("constructed", &false)
                 .err()
                 .expect("Failed to set 'constructed' property")
-                .description(),
+                .to_string(),
             "property is not writable",
         );
 
@@ -622,7 +622,7 @@ mod test {
             obj.set_property("name", &false)
                 .err()
                 .expect("Failed to set 'name' property")
-                .description(),
+                .to_string(),
             "property can't be set from the given type (expected: gchararray, got: gboolean)",
         );
 
@@ -631,7 +631,7 @@ mod test {
             obj.set_property("child", &other_obj)
                 .err()
                 .expect("Failed to set 'child' property")
-                .description(),
+                .to_string(),
             "property can't be set from the given object type (expected: ChildObject, got: SimpleObject)",
         );
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -119,11 +119,7 @@ impl fmt::Display for GetError {
     }
 }
 
-impl error::Error for GetError {
-    fn description(&self) -> &str {
-        "GetError: Value type mismatch"
-    }
-}
+impl error::Error for GetError {}
 
 /// A generic value capable of carrying various types.
 ///


### PR DESCRIPTION
`std::error::Error::description` is deprecated since 1.42.0. Doc says
`Display` should be used instead. Current implementation for `Display`
on `BoolError` displays all the fields, which can be obtained via the
`Debug` derive.

This commit changes the `Display` impl on `BoolError` to match
previous impl for the `Error::description`. Tests can use
`to_string` in place of `description` for the same result.

Same for `glib::Error` and `value::GetError`.

Fixes https://github.com/gtk-rs/glib/issues/613