### PR TITLE
Return a string of any lifetime from Quark::to_string()

### DIFF
--- a/src/quark.rs
+++ b/src/quark.rs
@@ -17,7 +17,7 @@ impl Quark {
     }
 
     #[allow(clippy::trivially_copy_pass_by_ref)]
-    pub fn to_string(&self) -> &'static str {
+    pub fn to_string<'a>(&self) -> &'a str {
         unsafe {
             CStr::from_ptr(glib_sys::g_quark_to_string(self.to_glib()))
                 .to_str()


### PR DESCRIPTION
Specifying it as 'static is very specific and instead we can let the
caller chose any lifetime they want here.

CC @GuillaumeGomez @EPashkin 