### PR TITLE
Clippy cleanliness and CI enforcement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,3 +108,7 @@ script:
       cd checker && cargo build --release;
       cd .. && ./checker/target/release/checker .;
     fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$TRAVIS_RUST_VERSION" == "stable"] && [ "$GTK" == "3.24" ]; then
+      rustup component add clippy;
+      cargo clippy --tests -- -D warnings;
+    fi

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -368,6 +368,8 @@ impl<T> fmt::Debug for AnyBox<T> {
     }
 }
 
+// The safety docs really belong in the glib_wrapper!() macro for Boxed<T>
+#[allow(clippy::missing_safety_doc)]
 /// Memory management functions for a boxed type.
 pub trait BoxedMemoryManager<T>: 'static {
     /// Makes a copy.

--- a/src/byte_array.rs
+++ b/src/byte_array.rs
@@ -244,9 +244,9 @@ mod tests {
         ba.remove_range(1, 2);
         ba.sort(|a, b| a.cmp(b));
         unsafe { ba.set_size(3) };
-        assert_eq!(ba, "aab".as_bytes());
+        assert_eq!(ba, b"aab" as &[u8]);
         let abc: &[u8] = b"abc";
-        assert_eq!(ByteArray::from(abc), "abc".as_bytes());
+        assert_eq!(ByteArray::from(abc), b"abc" as &[u8]);
     }
 
     #[test]

--- a/src/byte_array.rs
+++ b/src/byte_array.rs
@@ -97,6 +97,7 @@ impl ByteArray {
         }
     }
 
+    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn set_size(&self, size: usize) {
         glib_sys::g_byte_array_set_size(self.to_glib_none().0, size as u32);
     }

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -49,22 +49,22 @@ mod tests {
     #[test]
     fn update() {
         let mut cs = Checksum::new(CS_TYPE);
-        cs.update("hello world!".as_bytes());
+        cs.update(b"hello world!");
         assert_eq!(cs.get_string().unwrap(), CS_VALUE);
     }
 
     #[test]
     fn update_multi_call() {
         let mut cs = Checksum::new(CS_TYPE);
-        cs.update("hello ".as_bytes());
-        cs.update("world!".as_bytes());
+        cs.update(b"hello ");
+        cs.update(b"world!");
         assert_eq!(cs.get_string().unwrap(), CS_VALUE);
     }
 
     #[test]
     fn get_digest() {
         let mut cs = Checksum::new(CS_TYPE);
-        cs.update("hello world!".as_bytes());
+        cs.update(b"hello world!");
         let vec = cs.get_digest();
         assert_eq!(vec, CS_SLICE);
     }

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -41,6 +41,7 @@ impl Closure {
         unsafe { Closure::new_unsafe(move |values| (callback.get_ref())(values)) }
     }
 
+    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn new_unsafe<F: Fn(&[Value]) -> Option<Value>>(callback: F) -> Self {
         unsafe extern "C" fn marshal<F>(
             _closure: *mut gobject_sys::GClosure,

--- a/src/gstring.rs
+++ b/src/gstring.rs
@@ -417,6 +417,7 @@ impl_from_glib_container_as_vec_string!(GString, *const c_char);
 impl_from_glib_container_as_vec_string!(GString, *mut c_char);
 
 #[cfg(test)]
+#[allow(clippy::blacklisted_name)]
 mod tests {
     use glib_sys;
     use gstring::GString;

--- a/src/gstring.rs
+++ b/src/gstring.rs
@@ -476,7 +476,7 @@ mod tests {
 
     #[test]
     fn test_vec_u8_to_gstring() {
-        let v = "foo".as_bytes();
+        let v: &[u8] = b"foo";
         let s: GString = Vec::from(v).into();
         assert_eq!(s.as_str(), "foo");
     }

--- a/src/gstring.rs
+++ b/src/gstring.rs
@@ -47,7 +47,7 @@ impl GString {
     ///
     /// The underlying string must not be mutated, in particular in terms of
     /// length, underneath the `GString` instance.
-    pub unsafe fn new(ptr: *mut c_char) -> Self {
+    unsafe fn new(ptr: *mut c_char) -> Self {
         assert!(!ptr.is_null());
         GString(Inner::Foreign(ptr, libc::strlen(ptr)))
     }
@@ -64,7 +64,7 @@ impl GString {
     ///
     /// The underlying string must not be mutated, in particular in terms of
     /// length, underneath the `GString` instance for the duration of the borrow.
-    pub unsafe fn new_borrowed(ptr: *const c_char) -> Borrowed<Self> {
+    unsafe fn new_borrowed(ptr: *const c_char) -> Borrowed<Self> {
         assert!(!ptr.is_null());
         Borrowed::new(GString(Inner::Foreign(ptr as *mut _, libc::strlen(ptr))))
     }

--- a/src/log.rs
+++ b/src/log.rs
@@ -182,8 +182,9 @@ pub fn log_set_fatal_mask(log_domain: &str, fatal_levels: LogLevels) -> LogLevel
 //     }
 // }
 
-static PRINT_HANDLER: Lazy<Mutex<Option<Arc<dyn Fn(&str) + Send + Sync + 'static>>>> =
-    Lazy::new(|| Mutex::new(None));
+type PrintCallback = dyn Fn(&str) + Send + Sync + 'static;
+
+static PRINT_HANDLER: Lazy<Mutex<Option<Arc<PrintCallback>>>> = Lazy::new(|| Mutex::new(None));
 
 /// To set back the default print handler, use the [`unset_print_handler`] function.
 pub fn set_print_handler<P: Fn(&str) + Send + Sync + 'static>(func: P) {
@@ -210,8 +211,7 @@ pub fn unset_print_handler() {
     unsafe { glib_sys::g_set_print_handler(None) };
 }
 
-static PRINTERR_HANDLER: Lazy<Mutex<Option<Arc<dyn Fn(&str) + Send + Sync + 'static>>>> =
-    Lazy::new(|| Mutex::new(None));
+static PRINTERR_HANDLER: Lazy<Mutex<Option<Arc<PrintCallback>>>> = Lazy::new(|| Mutex::new(None));
 
 /// To set back the default print handler, use the [`unset_printerr_handler`] function.
 pub fn set_printerr_handler<P: Fn(&str) + Send + Sync + 'static>(func: P) {
@@ -241,9 +241,9 @@ pub fn unset_printerr_handler() {
     unsafe { glib_sys::g_set_printerr_handler(None) };
 }
 
-static DEFAULT_HANDLER: Lazy<
-    Mutex<Option<Arc<dyn Fn(&str, LogLevel, &str) + Send + Sync + 'static>>>,
-> = Lazy::new(|| Mutex::new(None));
+type LogCallback = dyn Fn(&str, LogLevel, &str) + Send + Sync + 'static;
+
+static DEFAULT_HANDLER: Lazy<Mutex<Option<Arc<LogCallback>>>> = Lazy::new(|| Mutex::new(None));
 
 /// To set back the default print handler, use the [`log_unset_default_handler`] function.
 pub fn log_set_default_handler<P: Fn(&str, LogLevel, &str) + Send + Sync + 'static>(log_func: P) {

--- a/src/main_context.rs
+++ b/src/main_context.rs
@@ -175,7 +175,7 @@ mod tests {
             let t = MainContext::get_thread_default().unwrap();
             assert!(is_same_context(&a, &t));
 
-            &b.with_thread_default(|| {
+            b.with_thread_default(|| {
                 let t = MainContext::get_thread_default().unwrap();
                 assert!(is_same_context(&b, &t));
             });
@@ -197,7 +197,7 @@ mod tests {
             assert!(is_same_context(&a, &t));
 
             let result = panic::catch_unwind(|| {
-                &b.with_thread_default(|| {
+                b.with_thread_default(|| {
                     panic!();
                 });
             });

--- a/src/main_context_futures.rs
+++ b/src/main_context_futures.rs
@@ -349,7 +349,10 @@ mod tests {
 
                     futures_util::future::ok(())
                 })
-                .then(|res| futures_util::future::ready(res.unwrap())),
+                .then(|res| {
+                    assert!(res.is_ok());
+                    futures_util::future::ready(())
+                }),
         );
 
         thread::spawn(move || {
@@ -358,7 +361,7 @@ mod tests {
 
         o_sender.send(()).unwrap();
 
-        let _ = receiver.recv().unwrap();
+        receiver.recv().unwrap();
     }
 
     #[test]

--- a/src/object.rs
+++ b/src/object.rs
@@ -1313,6 +1313,7 @@ pub trait ObjectExt: ObjectType {
     where
         N: Into<&'a str>,
         F: Fn(&[Value]) -> Option<Value> + 'static;
+    #[allow(clippy::missing_safety_doc)]
     unsafe fn connect_unsafe<'a, N, F>(
         &self,
         signal_name: N,
@@ -1334,6 +1335,7 @@ pub trait ObjectExt: ObjectType {
         name: Option<&str>,
         f: F,
     ) -> SignalHandlerId;
+    #[allow(clippy::missing_safety_doc)]
     unsafe fn connect_notify_unsafe<F: Fn(&Self, &::ParamSpec)>(
         &self,
         name: Option<&str>,

--- a/src/object.rs
+++ b/src/object.rs
@@ -59,6 +59,12 @@ pub unsafe trait ObjectType:
 
 /// Unsafe variant of the `From` trait.
 pub trait UnsafeFrom<T> {
+    /// # Safety
+    ///
+    /// It is the responsibility of the caller to ensure *all* invariants of
+    /// the `T` hold before this is called, and that subsequent to conversion
+    /// to assume nothing other than the invariants of the output.  Implementors
+    /// of this must ensure that the invariants of the output type hold.
     unsafe fn unsafe_from(t: T) -> Self;
 }
 
@@ -353,7 +359,14 @@ pub trait Cast: ObjectType {
 
     /// Casts to `T` unconditionally.
     ///
+    /// # Panics
+    ///
     /// Panics if compiled with `debug_assertions` and the instance doesn't implement `T`.
+    ///
+    /// # Safety
+    ///
+    /// If not running with `debug_assertions` enabled, the caller is responsible
+    /// for ensuring that the instance implements `T`
     unsafe fn unsafe_cast<T: ObjectType>(self) -> T {
         debug_assert!(self.is::<T>());
         T::unsafe_from(self.into())
@@ -361,7 +374,14 @@ pub trait Cast: ObjectType {
 
     /// Casts to `&T` unconditionally.
     ///
+    /// # Panics
+    ///
     /// Panics if compiled with `debug_assertions` and the instance doesn't implement `T`.
+    ///
+    /// # Safety
+    ///
+    /// If not running with `debug_assertions` enabled, the caller is responsible
+    /// for ensuring that the instance implements `T`
     unsafe fn unsafe_cast_ref<T: ObjectType>(&self) -> &T {
         debug_assert!(self.is::<T>());
         // This cast is safe because all our wrapper types have the

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -285,7 +285,17 @@ macro_rules! glib_shared_wrapper {
 }
 
 pub trait SharedMemoryManager<T> {
+    /// # Safety
+    ///
+    /// Callers are responsible for ensuring that a matching call to `unref`
+    /// is made at an appropriate time.
     unsafe fn ref_(ptr: *mut T);
+
+    /// # Safety
+    ///
+    /// Callers are responsible for ensuring that a matching call to `ref` was
+    /// made before this is called, and that the pointer is not used after the
+    /// `unref` call.
     unsafe fn unref(ptr: *mut T);
 }
 

--- a/src/source_futures.rs
+++ b/src/source_futures.rs
@@ -378,9 +378,7 @@ mod tests {
     fn test_timeout() {
         let c = MainContext::new();
 
-        let res = c.block_on(timeout_future(20));
-
-        assert_eq!(res, ());
+        c.block_on(timeout_future(20));
     }
 
     #[test]
@@ -405,18 +403,16 @@ mod tests {
 
         {
             let count = &mut count;
-            let res = c.block_on(
+            c.block_on(
                 interval_stream(20)
                     .take(2)
                     .for_each(|()| {
-                        *count = *count + 1;
+                        *count += 1;
 
                         futures_util::future::ready(())
                     })
                     .map(|_| ()),
             );
-
-            assert_eq!(res, ());
         }
 
         assert_eq!(count, 2);

--- a/src/subclass/types.rs
+++ b/src/subclass/types.rs
@@ -125,6 +125,11 @@ pub unsafe trait IsSubclassable<T: ObjectSubclass>: IsClassFor {
 /// Trait for implementable interfaces.
 pub unsafe trait IsImplementable<T: ObjectSubclass>: StaticType {
     /// Initializes the interface's virtual methods.
+    ///
+    /// # Safety
+    ///
+    /// It is the responsibility of the implementor of the interface to
+    /// correctly type the pointers when working on the vtables they point at.
     unsafe extern "C" fn interface_init(iface: glib_sys::gpointer, _iface_data: glib_sys::gpointer);
 }
 

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -137,6 +137,7 @@ pub fn const_override<T>(ptr: *mut T) -> *const T {
 /// A trait for creating an uninitialized value. Handy for receiving outparams.
 pub trait Uninitialized {
     /// Returns an uninitialized value.
+    #[allow(clippy::missing_safety_doc)]
     unsafe fn uninitialized() -> Self;
 }
 

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -203,6 +203,8 @@ impl<T> Borrowed<T> {
 
     /// Extracts the contained value.
     ///
+    /// # Safety
+    ///
     /// The returned value must never be dropped and instead has to be passed to `mem::forget()` or
     /// be directly wrapped in `mem::ManuallyDrop` or another `Borrowed` wrapper.
     pub unsafe fn into_inner(self) -> T {
@@ -1220,6 +1222,9 @@ impl FromGlib<i32> for Option<u64> {
 /// This is suitable for floating references, which become strong references.
 /// It is also suitable for acquiring non-gobject values, like `gchar*`.
 ///
+/// <a name="safety_points"></a>
+/// # Safety
+///
 /// The implementation of this trait should acquire a reference to the value
 /// in a way appropriate to the type,
 /// e.g. by increasing the reference count or copying.
@@ -1228,6 +1233,9 @@ impl FromGlib<i32> for Option<u64> {
 ///
 /// For more information, refer to module level documentation.
 pub trait FromGlibPtrNone<P: Ptr>: Sized {
+    /// # Safety
+    ///
+    /// See trait level [notes on safety](#safety_points)
     unsafe fn from_glib_none(ptr: P) -> Self;
 }
 
@@ -1237,6 +1245,9 @@ pub trait FromGlibPtrNone<P: Ptr>: Sized {
 /// Because ownership can only be transferred if something is already referenced,
 /// this is unsuitable for floating references.
 ///
+/// <a name="safety_points"></a>
+/// # Safety
+///
 /// The implementation of this trait should not alter the reference count
 /// or make copies of the underlying value.
 /// Values obtained using this trait must be properly released on `drop()`
@@ -1244,6 +1255,9 @@ pub trait FromGlibPtrNone<P: Ptr>: Sized {
 ///
 /// For more information, refer to module level documentation.
 pub trait FromGlibPtrFull<P: Ptr>: Sized {
+    /// # Safety
+    ///
+    /// See trait level [notes on safety](#safety_points)
     unsafe fn from_glib_full(ptr: P) -> Self;
 }
 
@@ -1254,6 +1268,9 @@ pub trait FromGlibPtrFull<P: Ptr>: Sized {
 /// The obtained borrow must not be accessed outside of the scope of the callback,
 /// and called procedures must not store any references to the underlying data.
 /// Safe Rust code must never obtain a mutable Rust reference.
+///
+/// <a name="safety_points"></a>
+/// # Safety
 ///
 /// The implementation of this trait as well as the returned type
 /// must satisfy the same constraints together.
@@ -1269,6 +1286,9 @@ pub trait FromGlibPtrFull<P: Ptr>: Sized {
 ///
 /// For more information, refer to module level documentation.
 pub trait FromGlibPtrBorrow<P: Ptr>: Sized {
+    /// # Safety
+    ///
+    /// See trait level [notes on safety](#safety_points)
     unsafe fn from_glib_borrow(_ptr: P) -> Borrowed<Self> {
         unimplemented!();
     }

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -1508,6 +1508,7 @@ impl FromGlibPtrFull<*mut c_char> for OsString {
 }
 
 /// Translate from a container.
+#[allow(clippy::missing_safety_doc)]
 pub trait FromGlibContainer<T, P: Ptr>: Sized {
     /// Transfer: none.
     ///
@@ -1526,6 +1527,7 @@ pub trait FromGlibContainer<T, P: Ptr>: Sized {
 }
 
 /// Translate from a container of pointers.
+#[allow(clippy::missing_safety_doc)]
 pub trait FromGlibPtrContainer<P: Ptr, PP: Ptr>: FromGlibContainer<P, PP> + Sized {
     /// Transfer: none.
     unsafe fn from_glib_none(ptr: PP) -> Self;
@@ -1550,6 +1552,7 @@ pub unsafe fn c_ptr_array_len<P: Ptr>(mut ptr: *const P) -> usize {
     len
 }
 
+#[allow(clippy::missing_safety_doc)]
 pub trait FromGlibContainerAsVec<T, P: Ptr>
 where
     Self: Sized,
@@ -1559,6 +1562,7 @@ where
     unsafe fn from_glib_full_num_as_vec(ptr: P, num: usize) -> Vec<Self>;
 }
 
+#[allow(clippy::missing_safety_doc)]
 pub trait FromGlibPtrArrayContainerAsVec<P: Ptr, PP: Ptr>: FromGlibContainerAsVec<P, PP>
 where
     Self: Sized,

--- a/src/value.rs
+++ b/src/value.rs
@@ -893,6 +893,10 @@ impl ToValue for SendValue {
 ///
 /// Types that don't support a `None` value always return `Some`.
 pub trait FromValueOptional<'a>: StaticType + Sized {
+    /// # Safety
+    ///
+    /// The caller is responsible for ensuring the given `Value` is of a suitable
+    /// type for this conversion.
     unsafe fn from_value_optional(&'a Value) -> Option<Self>;
 }
 
@@ -900,6 +904,10 @@ pub trait FromValueOptional<'a>: StaticType + Sized {
 ///
 /// Only implemented for types that don't support a `None` value.
 pub trait FromValue<'a>: FromValueOptional<'a> {
+    /// # Safety
+    ///
+    /// The caller is responsible for ensuring the given `Value` is of a suitable
+    /// type for this conversion.
     unsafe fn from_value(&'a Value) -> Self;
 }
 
@@ -907,11 +915,19 @@ pub trait FromValue<'a>: FromValueOptional<'a> {
 ///
 /// Only implemented for types that support a `None` value.
 pub trait SetValueOptional: SetValue {
+    /// # Safety
+    ///
+    /// The caller is responsible for ensuring the given `Value` is of a suitable
+    /// type for this conversion.
     unsafe fn set_value_optional(&mut Value, Option<&Self>);
 }
 
 /// Sets a value.
 pub trait SetValue: StaticType {
+    /// # Safety
+    ///
+    /// The caller is responsible for ensuring the given `Value` is of a suitable
+    /// type for this conversion.
     unsafe fn set_value(&mut Value, &Self);
 }
 

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -432,7 +432,7 @@ mod tests {
     fn test_string() {
         let s = String::from("this is a test");
         let v = Variant::from(s.clone());
-        assert_eq!(v.get(), Some(s.clone()));
+        assert_eq!(v.get(), Some(s));
     }
 
     #[test]

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -154,8 +154,18 @@ impl Variant {
         }
     }
 
-    /// Same as `new_from_bytes`, except checks on the passed data are skipped, which makes it a
-    /// potentially unsafe function. You should not use this function on data from external sources.
+    /// Constructs a new serialised-mode GVariant instance.
+    ///
+    /// This is the same as `new_from_bytes`, except that checks on the passed
+    /// data are skipped.
+    ///
+    /// You should not use this function on data from external sources.
+    ///
+    /// # Safety
+    ///
+    /// Since the data is not validated, this is potentially dangerous if called
+    /// on bytes which are not guaranteed to have come from serialising another
+    /// Variant.  The caller is responsible for ensuring bad data is not passed in.
     pub unsafe fn new_from_bytes_trusted<T: StaticVariantType>(bytes: &Bytes) -> Self {
         from_glib_none(glib_sys::g_variant_new_from_bytes(
             T::static_variant_type().as_ptr() as *const _,

--- a/src/variant_type.rs
+++ b/src/variant_type.rs
@@ -156,6 +156,11 @@ impl VariantTy {
     }
 
     /// Converts a type string into `&VariantTy` without any checks.
+    ///
+    /// # Safety
+    ///
+    /// The caller is responsible for passing in only a valid variant type string
+    /// which is already registered with the type system.
     pub unsafe fn from_str_unchecked(type_string: &str) -> &VariantTy {
         &*(type_string as *const str as *const VariantTy)
     }

--- a/tests/clone.rs
+++ b/tests/clone.rs
@@ -33,7 +33,8 @@ fn clone_and_references() {
         })
     };
 
-    assert_eq!(closure(), ());
+    closure();
+    assert_eq!(ref_state.borrow().started, true);
 }
 
 #[test]
@@ -68,7 +69,8 @@ fn renaming() {
         })
     };
 
-    assert_eq!(closure(), ());
+    closure();
+    assert_eq!(state.borrow().started, true);
 }
 
 #[test]
@@ -82,7 +84,7 @@ fn clone_closure() {
         })
     };
 
-    assert_eq!(closure(), ());
+    closure();
 
     assert_eq!(state.borrow().started, true);
     assert_eq!(state.borrow().count, 0);
@@ -98,7 +100,7 @@ fn clone_closure() {
         })
     };
 
-    assert_eq!(closure(), ());
+    closure();
 
     assert_eq!(state.borrow().count, 1);
     assert_eq!(state.borrow().started, true);
@@ -135,9 +137,7 @@ fn clone_panic() {
         closure(50);
     });
 
-    if result.is_ok() {
-        assert!(false, "should panic");
-    }
+    assert!(result.is_err());
 
     assert_eq!(state.lock().expect("Failed to lock state mutex").count, 20);
 }


### PR DESCRIPTION
This adds CI enforcement of clippy and cleans up a lot of its unhappiness.

There are a number of places where I silence lints rather than solving them, and care will need to be taken to consider unsilencing and fixing them properly in the future, but this is sufficient for now.