### PR TITLE
Ignore g_variant_get_gtype()

### DIFF
--- a/Gir.toml
+++ b/Gir.toml
@@ -432,6 +432,10 @@ status = "generate"
     pattern = "POLLFD_FORMAT"
     #for C printf
     ignore = true
+    [[object.function]]
+    name = "variant_get_gtype"
+    # get_type() function that should be used in StaticType impl instead
+    ignore = true
 
 [[object]]
 name = "GLib.Checksum"

--- a/src/auto/functions.rs
+++ b/src/auto/functions.rs
@@ -9,7 +9,6 @@ use std::boxed::Box as Box_;
 use std::mem;
 use std::ptr;
 use translate::*;
-use types;
 use Bytes;
 use ChecksumType;
 use Error;
@@ -1308,10 +1307,6 @@ pub fn uuid_string_is_valid(str: &str) -> bool {
 #[cfg(any(feature = "v2_52", feature = "dox"))]
 pub fn uuid_string_random() -> GString {
     unsafe { from_glib_full(glib_sys::g_uuid_string_random()) }
-}
-
-pub fn variant_get_gtype() -> types::Type {
-    unsafe { from_glib(glib_sys::g_variant_get_gtype()) }
 }
 
 //pub fn vasprintf(string: &str, format: &str, args: /*Unknown conversion*//*Unimplemented*/Unsupported) -> i32 {


### PR DESCRIPTION
It should be used by a StaticType impl, which we have, and not be
available as a standalone function.

----

CC @EPashkin @GuillaumeGomez 