### PR TITLE
Keep the scope of clone! macro arms in the crate

### DIFF
--- a/src/clone.rs
+++ b/src/clone.rs
@@ -457,7 +457,7 @@ macro_rules! clone {
         }
     );
     ($($(@ $strength:ident$(-$var:ident-$var2:ident)?)? $($variables:ident).+ $(as $rename:ident)?),+ => @default-panic, move || $body:expr ) => (
-        clone!($($(@ $strength$(-$var-$var2)?)? $($variables).+ $(as $rename)?),* => @default-panic, move || { $body })
+        $crate::clone!($($(@ $strength$(-$var-$var2)?)? $($variables).+ $(as $rename)?),* => @default-panic, move || { $body })
     );
     ($($(@ $strength:ident$(-$var:ident-$var2:ident)?)? $($variables:ident).+ $(as $rename:ident)?),+ => $(@default-return $return_value:expr,)? move || $body:block ) => (
         {
@@ -470,7 +470,7 @@ macro_rules! clone {
         }
     );
     ($($(@ $strength:ident$(-$var:ident-$var2:ident)?)? $($variables:ident).+ $(as $rename:ident)?),+ => $(@default-return $return_value:expr,)? move || $body:expr ) => (
-        clone!($($(@ $strength$(-$var-$var2)?)? $($variables).+ $(as $rename)?),* => $(@default-return $return_value,)? move || { $body })
+        $crate::clone!($($(@ $strength$(-$var-$var2)?)? $($variables).+ $(as $rename)?),* => $(@default-return $return_value,)? move || { $body })
     );
     ($($(@ $strength:ident$(-$var:ident-$var2:ident)?)? $($variables:ident).+ $(as $rename:ident)?),+ => @default-panic, move | $($arg:tt $(: $typ:ty)?),* | $body:block ) => (
         {
@@ -482,7 +482,7 @@ macro_rules! clone {
         }
     );
     ($($(@ $strength:ident$(-$var:ident-$var2:ident)?)? $($variables:ident).+ $(as $rename:ident)?),+ => @default-panic, move | $($arg:tt $(: $typ:ty)?),* | $body:expr ) => (
-        clone!($($(@ $strength$(-$var-$var2)?)? $($variables).+ $(as $rename)?),* => @default-panic, move |$($arg $(: $typ)?),*| { $body })
+        $crate::clone!($($(@ $strength$(-$var-$var2)?)? $($variables).+ $(as $rename)?),* => @default-panic, move |$($arg $(: $typ)?),*| { $body })
     );
     ($($(@ $strength:ident$(-$var:ident-$var2:ident)?)? $($variables:ident).+ $(as $rename:ident)?),+ => $(@default-return $return_value:expr,)? move | $($arg:tt $(: $typ:ty)?),* | $body:block ) => (
         {
@@ -495,7 +495,7 @@ macro_rules! clone {
         }
     );
     ($($(@ $strength:ident$(-$var:ident-$var2:ident)?)? $($variables:ident).+ $(as $rename:ident)?),+ => $(@default-return $return_value:expr,)? move | $($arg:tt $(: $typ:ty)?),* | $body:expr ) => (
-        clone!($($(@ $strength$(-$var-$var2)?)? $($variables).+ $(as $rename)?),+ => $(@default-return $return_value,)? move |$($arg $(: $typ)?),*| { $body })
+        $crate::clone!($($(@ $strength$(-$var-$var2)?)? $($variables).+ $(as $rename)?),+ => $(@default-return $return_value,)? move |$($arg $(: $typ)?),*| { $body })
     );
     ($($(@ $strength:ident$(-$var:ident-$var2:ident)?)? $($variables:ident).+ $(as $rename:ident)?),+ => @default-return $return_value:expr, || $($body:tt)* ) => (
         // In case we have:

--- a/tests/clone.rs
+++ b/tests/clone.rs
@@ -141,3 +141,32 @@ fn clone_panic() {
 
     assert_eq!(state.lock().expect("Failed to lock state mutex").count, 20);
 }
+
+#[test]
+fn clone_import_rename() {
+    import_rename::test();
+}
+
+mod import_rename {
+    use glib::clone as clone_g;
+
+    #[allow(unused_macros)]
+    macro_rules! clone {
+        ($($anything:tt)*) => {
+            |_, _| panic!("The clone! macro doesn't support renaming")
+        };
+    }
+
+    #[allow(unused_variables)]
+    pub fn test() {
+        let n = 2;
+
+        let closure: Box<dyn Fn(u32, u32)> = Box::new(clone_g!(
+            @strong n
+            => move |_, _|
+            println!("The clone! macro does support renaming")
+        ));
+
+        closure(0, 0);
+    }
+}


### PR DESCRIPTION
When doing recursive calls in the macro, it calls itself by its raw name. This is a problem when importing and renaming it. This fix makes that possible.