### PR TITLE
fix: Do not transfer ownership in Variant::new_variant()

### DIFF
--- a/src/variant.rs
+++ b/src/variant.rs
@@ -176,7 +176,7 @@ impl Variant {
     /// Boxes value.
     #[inline]
     pub fn new_variant(value: &Variant) -> Self {
-        unsafe { from_glib_full(glib_sys::g_variant_new_variant(value.to_glib_full())) }
+        unsafe { from_glib_none(glib_sys::g_variant_new_variant(value.to_glib_none().0)) }
     }
 
     /// Unboxes self.


### PR DESCRIPTION
Trying to port some code to the new variant API, this was causing errors.

I believe this is correct now.