### PR TITLE
Drop "new_" prefix from Variant constructor methods

### DIFF
--- a/src/variant.rs
+++ b/src/variant.rs
@@ -39,13 +39,13 @@
 //! assert_eq!(num.get_str(), None);
 //!
 //! // Variant carrying a Variant
-//! let variant = Variant::new_variant(&hello);
+//! let variant = Variant::variant(&hello);
 //! let variant = variant.get_variant().unwrap();
 //! assert_eq!(variant.get_str(), Some("Hello!"));
 //!
 //! // Variant carrying an array
 //! let array = [Variant::from("Hello"), Variant::from("there!")];
-//! let variant = Variant::new_array::<&str>(&array);
+//! let variant = Variant::array::<&str>(&array);
 //! assert_eq!(variant.n_children(), 2);
 //! assert_eq!(variant.get_child_value(0).get_str(), Some("Hello"));
 //! assert_eq!(variant.get_child_value(1).get_str(), Some("there!"));
@@ -175,7 +175,7 @@ impl Variant {
 
     /// Boxes value.
     #[inline]
-    pub fn new_variant(value: &Variant) -> Self {
+    pub fn variant(value: &Variant) -> Self {
         unsafe { from_glib_none(glib_sys::g_variant_new_variant(value.to_glib_none().0)) }
     }
 
@@ -230,7 +230,7 @@ impl Variant {
     /// Creates a new GVariant array from children.
     ///
     /// All children must be of type `T`.
-    pub fn new_array<T: StaticVariantType>(children: &[Variant]) -> Self {
+    pub fn array<T: StaticVariantType>(children: &[Variant]) -> Self {
         let type_ = T::static_variant_type();
 
         for child in children {
@@ -246,7 +246,7 @@ impl Variant {
     }
 
     /// Creates a new GVariant tuple from children.
-    pub fn new_tuple(children: &[Variant]) -> Self {
+    pub fn tuple(children: &[Variant]) -> Self {
         unsafe {
             from_glib_none(glib_sys::g_variant_new_tuple(
                 children.to_glib_none().0,
@@ -256,7 +256,7 @@ impl Variant {
     }
 
     /// Creates a new maybe Variant.
-    pub fn new_maybe<T: StaticVariantType>(child: Option<&Variant>) -> Self {
+    pub fn maybe<T: StaticVariantType>(child: Option<&Variant>) -> Self {
         let type_ = T::static_variant_type();
         let ptr = match child {
             Some(child) => {
@@ -542,7 +542,7 @@ impl<T: StaticVariantType> StaticVariantType for Option<T> {
 
 impl<T: StaticVariantType + ToVariant> ToVariant for Option<T> {
     fn to_variant(&self) -> Variant {
-        Variant::new_maybe::<T>(self.as_ref().map(|m| m.to_variant()).as_ref())
+        Variant::maybe::<T>(self.as_ref().map(|m| m.to_variant()).as_ref())
     }
 }
 
@@ -597,7 +597,7 @@ impl<T: StaticVariantType + ToVariant> ToVariant for Vec<T> {
         for child in self {
             vec.push(child.to_variant());
         }
-        Variant::new_array::<T>(&vec)
+        Variant::array::<T>(&vec)
     }
 }
 
@@ -645,7 +645,7 @@ where
             let entry = DictEntry::new(key, value).to_variant();
             vec.push(entry);
         }
-        Variant::new_array::<DictEntry<K, V>>(&vec)
+        Variant::array::<DictEntry<K, V>>(&vec)
     }
 }
 
@@ -664,7 +664,7 @@ where
 ///     DictEntry::new("uuid", 1000u32).to_variant(),
 ///     DictEntry::new("guid", 1001u32).to_variant(),
 /// ];
-/// let dict = Variant::new_array::<DictEntry<&str, u32>>(&entries);
+/// let dict = Variant::array::<DictEntry<&str, u32>>(&entries);
 /// assert_eq!(dict.n_children(), 2);
 /// assert_eq!(dict.type_().to_str(), "a{su}");
 /// ```
@@ -799,7 +799,7 @@ macro_rules! tuple_impls {
                         let field = self.$n.to_variant();
                         fields.push(field);
                     )+
-                    Variant::new_tuple(&fields)
+                    Variant::tuple(&fields)
                 }
             }
         )+

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -196,7 +196,13 @@ impl Variant {
     pub fn get_child_value(&self, index: usize) -> Variant {
         assert!(index < self.n_children());
         let ty = self.type_().to_str();
-        assert!(ty.starts_with("a") || ty.starts_with("{") || ty.starts_with("("));
+        assert!(
+            ty.starts_with("a")
+                || ty.starts_with("{")
+                || ty.starts_with("(")
+                || ty.starts_with("m")
+                || ty == "v"
+        );
 
         unsafe {
             from_glib_none(glib_sys::g_variant_get_child_value(


### PR DESCRIPTION
For consistency with rest of the API and Rust conventions.

Fixes #680.