### PR TITLE
Fix for g_param_spec_types symbol linking error with MSVC

### DIFF
--- a/src/param_spec.rs
+++ b/src/param_spec.rs
@@ -611,6 +611,7 @@ pub trait ParamSpecType:
 {
 }
 
+#[link(name = "gobject-2.0")]
 extern "C" {
     pub static g_param_spec_types: *const glib_sys::GType;
 }


### PR DESCRIPTION
Regression from https://github.com/gtk-rs/glib/pull/688

cc: @sdroege 