### PR TITLE
Added register_glib_to_logcrate_logger function to do glib-to-rust logging

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,10 +200,13 @@ pub use log::{
 };
 
 #[cfg(any(feature = "log", feature = "dox"))]
+extern crate log as rs_log;
+
+#[cfg(any(feature = "log", feature = "dox"))]
 #[macro_use]
 mod bridged_logging;
 #[cfg(any(feature = "log", feature = "dox"))]
-pub use bridged_logging::{GlibLogger, GlibLoggerDomain, GlibLoggerFormat};
+pub use bridged_logging::{rust_log_handler, GlibLogger, GlibLoggerDomain, GlibLoggerFormat};
 
 pub mod send_unique;
 pub use send_unique::{SendUnique, SendUniqueCell};


### PR DESCRIPTION
This adds a new `register_glib_to_logcrate_logger` function which routes all logging happening into glib to the log crate commonly used in Rust.

This is basically the reverse of `GlibLogger` (which routes the log crate to glib).

I found no trivial way (due to the fact that GlibLogger has a `const fn` constructor to simplify integration etc.) to prevent the user to use both `GlibLogger` and `register_glib_to_logcrate_logger` at the same time, which causes an obvious stack overflow (luckily, very early in the application lifetime). 

I clarified the potential stack overflow in the documentation. If preferred, different cargo features can be used to "xor" the two functionalities; I felt that to be more complicated than the problem it solved but it's personal opinion :)

Related issue: https://github.com/gtk-rs/glib/issues/658