### PR TITLE
Fix .get_instance() assert failure with zero-sized type

### DIFF
--- a/src/subclass/object.rs
+++ b/src/subclass/object.rs
@@ -577,6 +577,7 @@ mod test {
         // itself. No private/impl data is allocated for zero-sized types.
         let imp = ChildObject::from_instance(&obj);
         assert_eq!(imp as *const _ as *const (), obj.as_ptr() as *const _);
+        assert_eq!(obj, imp.get_instance());
     }
 
     #[test]

--- a/src/subclass/types.rs
+++ b/src/subclass/types.rs
@@ -297,7 +297,6 @@ pub trait ObjectSubclass: Sized + 'static {
             assert_ne!(type_, Type::Invalid);
 
             let offset = -data.as_ref().private_offset;
-            assert_ne!(offset, 0);
 
             let ptr = self as *const Self as *const u8;
             let ptr = ptr.offset(offset);


### PR DESCRIPTION
Also adds a call to `.get_instance()` to a test (which fails without the other change).

Fixes #701