### PR TITLE
Use :ty rather than :path for ffi_name and ffi_class_name

### DIFF
--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -16,7 +16,7 @@ use translate::*;
 /// Wrapper implementations for Boxed types. See `glib_wrapper!`.
 #[macro_export]
 macro_rules! glib_boxed_wrapper {
-    ([$($attr:meta)*] $name:ident, $ffi_name:path, @copy $copy_arg:ident $copy_expr:expr,
+    ([$($attr:meta)*] $name:ident, $ffi_name:ty, @copy $copy_arg:ident $copy_expr:expr,
      @free $free_arg:ident $free_expr:expr, @init $init_arg:ident $init_expr:expr, @clear $clear_arg:ident $clear_expr:expr,
      @get_type $get_type_expr:expr) => {
         glib_boxed_wrapper!(@generic_impl [$($attr)*] $name, $ffi_name);
@@ -25,27 +25,27 @@ macro_rules! glib_boxed_wrapper {
         glib_boxed_wrapper!(@value_impl $name, $ffi_name, @get_type $get_type_expr);
     };
 
-    ([$($attr:meta)*] $name:ident, $ffi_name:path, @copy $copy_arg:ident $copy_expr:expr,
+    ([$($attr:meta)*] $name:ident, $ffi_name:ty, @copy $copy_arg:ident $copy_expr:expr,
      @free $free_arg:ident $free_expr:expr, @init $init_arg:ident $init_expr:expr, @clear $clear_arg:ident $clear_expr:expr) => {
         glib_boxed_wrapper!(@generic_impl [$($attr)*] $name, $ffi_name);
         glib_boxed_wrapper!(@memory_manager_impl $name, $ffi_name, @copy $copy_arg $copy_expr, @free $free_arg $free_expr,
                             @init $init_arg $init_expr, @clear $clear_arg $clear_expr);
     };
 
-    ([$($attr:meta)*] $name:ident, $ffi_name:path, @copy $copy_arg:ident $copy_expr:expr,
+    ([$($attr:meta)*] $name:ident, $ffi_name:ty, @copy $copy_arg:ident $copy_expr:expr,
      @free $free_arg:ident $free_expr:expr) => {
         glib_boxed_wrapper!(@generic_impl [$($attr)*] $name, $ffi_name);
         glib_boxed_wrapper!(@memory_manager_impl $name, $ffi_name, @copy $copy_arg $copy_expr, @free $free_arg $free_expr);
     };
 
-    ([$($attr:meta)*] $name:ident, $ffi_name:path, @copy $copy_arg:ident $copy_expr:expr,
+    ([$($attr:meta)*] $name:ident, $ffi_name:ty, @copy $copy_arg:ident $copy_expr:expr,
      @free $free_arg:ident $free_expr:expr, @get_type $get_type_expr:expr) => {
         glib_boxed_wrapper!(@generic_impl [$($attr)*] $name, $ffi_name);
         glib_boxed_wrapper!(@memory_manager_impl $name, $ffi_name, @copy $copy_arg $copy_expr, @free $free_arg $free_expr);
         glib_boxed_wrapper!(@value_impl $name, $ffi_name, @get_type $get_type_expr);
     };
 
-    (@generic_impl [$($attr:meta)*] $name:ident, $ffi_name:path) => {
+    (@generic_impl [$($attr:meta)*] $name:ident, $ffi_name:ty) => {
         $(#[$attr])*
         #[derive(Clone)]
         pub struct $name($crate::boxed::Boxed<$ffi_name, MemoryManager>);
@@ -256,7 +256,7 @@ macro_rules! glib_boxed_wrapper {
         }
     };
 
-    (@value_impl $name:ident, $ffi_name:path, @get_type $get_type_expr:expr) => {
+    (@value_impl $name:ident, $ffi_name:ty, @get_type $get_type_expr:expr) => {
         impl $crate::types::StaticType for $name {
             fn static_type() -> $crate::types::Type {
                 #[allow(unused_unsafe)]
@@ -289,7 +289,7 @@ macro_rules! glib_boxed_wrapper {
         }
     };
 
-    (@memory_manager_impl $name:ident, $ffi_name:path, @copy $copy_arg:ident $copy_expr:expr, @free $free_arg:ident $free_expr:expr) => {
+    (@memory_manager_impl $name:ident, $ffi_name:ty, @copy $copy_arg:ident $copy_expr:expr, @free $free_arg:ident $free_expr:expr) => {
         #[doc(hidden)]
         pub enum MemoryManager {}
 
@@ -316,7 +316,7 @@ macro_rules! glib_boxed_wrapper {
         }
     };
 
-    (@memory_manager_impl $name:ident, $ffi_name:path, @copy $copy_arg:ident $copy_expr:expr, @free $free_arg:ident $free_expr:expr,
+    (@memory_manager_impl $name:ident, $ffi_name:ty, @copy $copy_arg:ident $copy_expr:expr, @free $free_arg:ident $free_expr:expr,
          @init $init_arg:ident $init_expr:expr, @clear $clear_arg:ident $clear_expr:expr) => {
         #[doc(hidden)]
         pub struct MemoryManager;

--- a/src/object.rs
+++ b/src/object.rs
@@ -718,7 +718,7 @@ macro_rules! glib_weak_impl {
 /// ObjectType implementations for Object types. See `glib_wrapper!`.
 #[macro_export]
 macro_rules! glib_object_wrapper {
-    (@generic_impl [$($attr:meta)*] $name:ident, $ffi_name:path, $ffi_class_name:path, $rust_class_name:path, @get_type $get_type_expr:expr) => {
+    (@generic_impl [$($attr:meta)*] $name:ident, $ffi_name:ty, $ffi_class_name:ty, $rust_class_name:path, @get_type $get_type_expr:expr) => {
         $(#[$attr])*
         // Always derive Hash/Ord (and below impl Debug, PartialEq, Eq, PartialOrd) for object
         // types. Due to inheritance and up/downcasting we must implement these by pointer or
@@ -1174,7 +1174,7 @@ macro_rules! glib_object_wrapper {
         $crate::glib_object_wrapper!(@munch_impls $name, $($implements)*);
     };
 
-    (@class_impl $name:ident, $ffi_class_name:path, $rust_class_name:ident) => {
+    (@class_impl $name:ident, $ffi_class_name:ty, $rust_class_name:ident) => {
         #[repr(C)]
         #[derive(Debug)]
         pub struct $rust_class_name($ffi_class_name);
@@ -1189,13 +1189,13 @@ macro_rules! glib_object_wrapper {
 
     // This case is only for glib::Object itself below. All other cases have glib::Object in its
     // parent class list
-    (@object [$($attr:meta)*] $name:ident, $ffi_name:path, $ffi_class_name:path, $rust_class_name:ident, @get_type $get_type_expr:expr) => {
+    (@object [$($attr:meta)*] $name:ident, $ffi_name:ty, $ffi_class_name:ty, $rust_class_name:ident, @get_type $get_type_expr:expr) => {
         $crate::glib_object_wrapper!(@generic_impl [$($attr)*] $name, $ffi_name, $ffi_class_name, $rust_class_name,
             @get_type $get_type_expr);
         $crate::glib_object_wrapper!(@class_impl $name, $ffi_class_name, $rust_class_name);
     };
 
-    (@object [$($attr:meta)*] $name:ident, $ffi_name:path, $ffi_class_name:path, $rust_class_name:ident,
+    (@object [$($attr:meta)*] $name:ident, $ffi_name:ty, $ffi_class_name:ty, $rust_class_name:ident,
         @get_type $get_type_expr:expr, @extends [$($extends:tt)*], @implements [$($implements:tt)*]) => {
         $crate::glib_object_wrapper!(@generic_impl [$($attr)*] $name, $ffi_name, $ffi_class_name, $rust_class_name,
             @get_type $get_type_expr);
@@ -1214,7 +1214,7 @@ macro_rules! glib_object_wrapper {
         unsafe impl $crate::object::IsA<$crate::object::Object> for $name { }
     };
 
-    (@interface [$($attr:meta)*] $name:ident, $ffi_name:path, @get_type $get_type_expr:expr, @requires [$($requires:tt)*]) => {
+    (@interface [$($attr:meta)*] $name:ident, $ffi_name:ty, @get_type $get_type_expr:expr, @requires [$($requires:tt)*]) => {
         $crate::glib_object_wrapper!(@generic_impl [$($attr)*] $name, $ffi_name, $crate::wrapper::Void, $crate::wrapper::Void,
             @get_type $get_type_expr);
         $crate::glib_object_wrapper!(@munch_impls $name, $($requires)*);

--- a/src/object.rs
+++ b/src/object.rs
@@ -718,7 +718,7 @@ macro_rules! glib_weak_impl {
 /// ObjectType implementations for Object types. See `glib_wrapper!`.
 #[macro_export]
 macro_rules! glib_object_wrapper {
-    (@generic_impl [$($attr:meta)*] $name:ident, $ffi_name:ty, $ffi_class_name:ty, $rust_class_name:path, @get_type $get_type_expr:expr) => {
+    (@generic_impl [$($attr:meta)*] $name:ident, $ffi_name:ty, $ffi_class_name:ty, $rust_class_name:ty, @get_type $get_type_expr:expr) => {
         $(#[$attr])*
         // Always derive Hash/Ord (and below impl Debug, PartialEq, Eq, PartialOrd) for object
         // types. Due to inheritance and up/downcasting we must implement these by pointer or
@@ -1215,7 +1215,7 @@ macro_rules! glib_object_wrapper {
     };
 
     (@interface [$($attr:meta)*] $name:ident, $ffi_name:ty, @get_type $get_type_expr:expr, @requires [$($requires:tt)*]) => {
-        $crate::glib_object_wrapper!(@generic_impl [$($attr)*] $name, $ffi_name, $crate::wrapper::Void, $crate::wrapper::Void,
+        $crate::glib_object_wrapper!(@generic_impl [$($attr)*] $name, $ffi_name, (), (),
             @get_type $get_type_expr);
         $crate::glib_object_wrapper!(@munch_impls $name, $($requires)*);
 

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -14,7 +14,7 @@ use translate::*;
 /// Wrapper implementations for shared types. See `glib_wrapper!`.
 #[macro_export]
 macro_rules! glib_shared_wrapper {
-    ([$($attr:meta)*] $name:ident, $ffi_name:path, @ref $ref_arg:ident $ref_expr:expr,
+    ([$($attr:meta)*] $name:ident, $ffi_name:ty, @ref $ref_arg:ident $ref_expr:expr,
      @unref $unref_arg:ident $unref_expr:expr,
      @get_type $get_type_expr:expr) => {
         glib_shared_wrapper!([$($attr)*] $name, $ffi_name, @ref $ref_arg $ref_expr,
@@ -52,7 +52,7 @@ macro_rules! glib_shared_wrapper {
         }
     };
 
-    ([$($attr:meta)*] $name:ident, $ffi_name:path, @ref $ref_arg:ident $ref_expr:expr,
+    ([$($attr:meta)*] $name:ident, $ffi_name:ty, @ref $ref_arg:ident $ref_expr:expr,
      @unref $unref_arg:ident $unref_expr:expr) => {
         $(#[$attr])*
         #[derive(Clone)]

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -240,7 +240,7 @@ macro_rules! glib_wrapper {
 
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Boxed<$ffi_name:path>);
+        pub struct $name:ident(Boxed<$ffi_name:ty>);
 
         match fn {
             copy => |$copy_arg:ident| $copy_expr:expr,
@@ -253,7 +253,7 @@ macro_rules! glib_wrapper {
 
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Boxed<$ffi_name:path>);
+        pub struct $name:ident(Boxed<$ffi_name:ty>);
 
         match fn {
             copy => |$copy_arg:ident| $copy_expr:expr,
@@ -267,7 +267,7 @@ macro_rules! glib_wrapper {
 
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Boxed<$ffi_name:path>);
+        pub struct $name:ident(Boxed<$ffi_name:ty>);
 
         match fn {
             copy => |$copy_arg:ident| $copy_expr:expr,
@@ -282,7 +282,7 @@ macro_rules! glib_wrapper {
 
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Boxed<$ffi_name:path>);
+        pub struct $name:ident(Boxed<$ffi_name:ty>);
 
         match fn {
             copy => |$copy_arg:ident| $copy_expr:expr,
@@ -301,7 +301,7 @@ macro_rules! glib_wrapper {
 
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Shared<$ffi_name:path>);
+        pub struct $name:ident(Shared<$ffi_name:ty>);
 
         match fn {
             ref => |$ref_arg:ident| $ref_expr:expr,
@@ -314,7 +314,7 @@ macro_rules! glib_wrapper {
 
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Shared<$ffi_name:path>);
+        pub struct $name:ident(Shared<$ffi_name:ty>);
 
         match fn {
             ref => |$ref_arg:ident| $ref_expr:expr,
@@ -329,7 +329,7 @@ macro_rules! glib_wrapper {
     // Object, no class struct, no parents or interfaces
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Object<$ffi_name:path, $rust_class_name:ident>);
+        pub struct $name:ident(Object<$ffi_name:ty, $rust_class_name:ident>);
 
         match fn {
             get_type => || $get_type_expr:expr,
@@ -341,7 +341,7 @@ macro_rules! glib_wrapper {
     // Object, class struct, no parents or interfaces
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Object<$ffi_name:path, $ffi_class_name:path, $rust_class_name:ident>);
+        pub struct $name:ident(Object<$ffi_name:ty, $ffi_class_name:ty, $rust_class_name:ident>);
 
         match fn {
             get_type => || $get_type_expr:expr,
@@ -353,7 +353,7 @@ macro_rules! glib_wrapper {
     // Object, no class struct, parents, no interfaces
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Object<$ffi_name:path, $rust_class_name:ident>) @extends $($extends:path),+;
+        pub struct $name:ident(Object<$ffi_name:ty, $rust_class_name:ident>) @extends $($extends:path),+;
 
         match fn {
             get_type => || $get_type_expr:expr,
@@ -366,7 +366,7 @@ macro_rules! glib_wrapper {
     // Object, class struct, parents, no interfaces
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Object<$ffi_name:path, $ffi_class_name:path, $rust_class_name:ident>) @extends $($extends:path),+;
+        pub struct $name:ident(Object<$ffi_name:ty, $ffi_class_name:ty, $rust_class_name:ident>) @extends $($extends:path),+;
 
         match fn {
             get_type => || $get_type_expr:expr,
@@ -379,7 +379,7 @@ macro_rules! glib_wrapper {
     // Object, no class struct, no parents, interfaces
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Object<$ffi_name:path, $rust_class_name:ident>) @implements $($implements:path),+;
+        pub struct $name:ident(Object<$ffi_name:ty, $rust_class_name:ident>) @implements $($implements:path),+;
 
         match fn {
             get_type => || $get_type_expr:expr,
@@ -392,7 +392,7 @@ macro_rules! glib_wrapper {
     // Object, class struct, no parents, interfaces
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Object<$ffi_name:path, $ffi_class_name:path, $rust_class_name:ident>) @implements $($implements:path),+;
+        pub struct $name:ident(Object<$ffi_name:ty, $ffi_class_name:ty, $rust_class_name:ident>) @implements $($implements:path),+;
 
         match fn {
             get_type => || $get_type_expr:expr,
@@ -405,7 +405,7 @@ macro_rules! glib_wrapper {
     // Object, no class struct, parents and interfaces
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Object<$ffi_name:path, $rust_class_name:ident>) @extends $($extends:path),+, @implements $($implements:path),+;
+        pub struct $name:ident(Object<$ffi_name:ty, $rust_class_name:ident>) @extends $($extends:path),+, @implements $($implements:path),+;
 
         match fn {
             get_type => || $get_type_expr:expr,
@@ -418,7 +418,7 @@ macro_rules! glib_wrapper {
     // Object, class struct, parents and interfaces
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Object<$ffi_name:path, $ffi_class_name:path, $rust_class_name:ident>) @extends $($extends:path),+, @implements $($implements:path),+;
+        pub struct $name:ident(Object<$ffi_name:ty, $ffi_class_name:ty, $rust_class_name:ident>) @extends $($extends:path),+, @implements $($implements:path),+;
 
         match fn {
             get_type => || $get_type_expr:expr,
@@ -431,7 +431,7 @@ macro_rules! glib_wrapper {
     // Interface, no prerequisites
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Interface<$ffi_name:path>);
+        pub struct $name:ident(Interface<$ffi_name:ty>);
 
         match fn {
             get_type => || $get_type_expr:expr,
@@ -443,7 +443,7 @@ macro_rules! glib_wrapper {
     // Interface, prerequisites
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Interface<$ffi_name:path>) @requires $($requires:path),+;
+        pub struct $name:ident(Interface<$ffi_name:ty>) @requires $($requires:path),+;
 
         match fn {
             get_type => || $get_type_expr:expr,

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -335,7 +335,7 @@ macro_rules! glib_wrapper {
             get_type => || $get_type_expr:expr,
         }
     ) => {
-        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, $crate::wrapper::Void, $rust_class_name, @get_type $get_type_expr, @extends [], @implements []);
+        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, (), $rust_class_name, @get_type $get_type_expr, @extends [], @implements []);
     };
 
     // Object, class struct, no parents or interfaces
@@ -359,7 +359,7 @@ macro_rules! glib_wrapper {
             get_type => || $get_type_expr:expr,
         }
     ) => {
-        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, $crate::wrapper::Void, $rust_class_name,
+        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, (), $rust_class_name,
             @get_type $get_type_expr, @extends [$($extends),+], @implements []);
     };
 
@@ -385,7 +385,7 @@ macro_rules! glib_wrapper {
             get_type => || $get_type_expr:expr,
         }
     ) => {
-        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, $crate::wrapper::Void, $rust_class_name,
+        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, (), $rust_class_name,
             @get_type $get_type_expr, @extends [], @implements [$($implements),+]);
     };
 
@@ -411,7 +411,7 @@ macro_rules! glib_wrapper {
             get_type => || $get_type_expr:expr,
         }
     ) => {
-        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, $crate::wrapper::Void, $rust_class_name,
+        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, (), $rust_class_name,
             @get_type $get_type_expr, @extends [$($extends),+], @implements [$($implements),+]);
     };
 
@@ -452,6 +452,3 @@ macro_rules! glib_wrapper {
         $crate::glib_object_wrapper!(@interface [$($attr)*] $name, $ffi_name, @get_type $get_type_expr, @requires [$($requires),+]);
     };
 }
-
-// So we can refer to the empty type by a path
-pub type Void = ();


### PR DESCRIPTION
I believe this is more correct, and should allow more things to work without breaking anything. But it's hard to be sure with complicated macros...

This allows code like this to compile:

```rust
glib_wrapper! {
    pub struct SimpleObject(
        Object<(<SimpleObjectPrivate as ObjectSubclass>::Instance),
        (<SimpleObjectPrivate as ObjectSubclass>::Class), SimpleObjectClass>)
        @extends gtk::Widget;

    match fn {
        get_type => || SimpleObjectPrivate::get_type().to_glib(),
    }
}
```