### PR TITLE
Add a ObjectSubclass version of glib_wrapper!

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -758,7 +758,7 @@ macro_rules! glib_object_wrapper {
             }
 
             fn as_ptr(&self) -> *mut Self::GlibType {
-                self.0.to_glib_none().0 as *mut _
+                $crate::translate::ToGlibPtr::to_glib_none(&self.0).0 as *mut _
             }
         }
 
@@ -1072,7 +1072,7 @@ macro_rules! glib_object_wrapper {
                 }
 
                 // And take the reference to the object from above to pass it to the caller
-                Option::<$name>::from_glib_full(obj as *mut $ffi_name).map(|o| $crate::object::Cast::unsafe_cast(o))
+                <Option::<$name> as $crate::translate::FromGlibPtrFull<*mut $ffi_name>>::from_glib_full(obj as *mut $ffi_name).map(|o| $crate::object::Cast::unsafe_cast(o))
             }
         }
 

--- a/src/subclass/mod.rs
+++ b/src/subclass/mod.rs
@@ -91,7 +91,7 @@
 //! // This is the struct containing all state carried with
 //! // the new type. Generally this has to make use of
 //! // interior mutability.
-//! pub struct SimpleObject {
+//! pub struct SimpleObjectPrivate {
 //!     name: RefCell<Option<String>>,
 //!     animal: Cell<Animal>,
 //!     flags: Cell<MyFlags>,
@@ -100,7 +100,7 @@
 //! // ObjectSubclass is the trait that defines the new type and
 //! // contains all information needed by the GObject type system,
 //! // including the new type's name, parent type, etc.
-//! impl ObjectSubclass for SimpleObject {
+//! impl ObjectSubclass for SimpleObjectPrivate {
 //!     // This type name must be unique per process.
 //!     const NAME: &'static str = "SimpleObject";
 //!
@@ -137,7 +137,7 @@
 //! }
 //!
 //! // Trait that is used to override virtual methods of glib::Object.
-//! impl ObjectImpl for SimpleObject {
+//! impl ObjectImpl for SimpleObjectPrivate {
 //!     // Called whenever a property is set on this instance. The id
 //!     // is the same as the index of the property in the PROPERTIES array.
 //!     fn set_property(&self, _obj: &glib::Object, id: usize, value: &glib::Value) {
@@ -189,9 +189,23 @@
 //!     }
 //! }
 //!
-//! pub fn main() {
+//! // Optionally, define a wrapper type to make it more ergonomic to use from Rust
+//! glib_wrapper! {
+//!     pub struct SimpleObject(ObjectSubclass<SimpleObjectPrivate, SimpleObjectClass>);
+//! }
+//!
+//! impl SimpleObject {
 //!     // Create an object instance of the new type.
-//!     let obj = glib::Object::new(SimpleObject::get_type(), &[]).unwrap();
+//!     pub fn new() -> Self {
+//!         glib::Object::new(Self::static_type(), &[])
+//!             .unwrap()
+//!             .downcast()
+//!             .unwrap()
+//!     }
+//! }
+//!
+//! pub fn main() {
+//!     let obj = SimpleObject::new();
 //!
 //!     // Get the name property and change its value.
 //!     assert_eq!(obj.get_property("name").unwrap().get::<&str>(), Ok(None));

--- a/src/subclass/mod.rs
+++ b/src/subclass/mod.rs
@@ -55,143 +55,147 @@
 //!     }
 //! }
 //!
-//! // Static array for defining the properties of the new type.
-//! static PROPERTIES: [subclass::Property; 3] = [
-//!     subclass::Property("name", |name| {
-//!         glib::ParamSpec::string(
-//!             name,
-//!             "Name",
-//!             "Name of this object",
-//!             None,
-//!             glib::ParamFlags::READWRITE,
-//!         )
-//!     }),
-//!     subclass::Property("animal", |name| {
-//!         glib::ParamSpec::enum_(
-//!             name,
-//!             "Animal",
-//!             "Animal",
-//!             Animal::static_type(),
-//!             Animal::default() as i32,
-//!             glib::ParamFlags::READWRITE,
-//!         )
-//!     }),
-//!     subclass::Property("flags", |name| {
-//!         glib::ParamSpec::flags(
-//!             name,
-//!             "Flags",
-//!             "Flags",
-//!             MyFlags::static_type(),
-//!             MyFlags::default().bits(),
-//!             glib::ParamFlags::READWRITE,
-//!         )
-//!     }),
-//! ];
+//! mod imp {
+//!     use super::*;
 //!
-//! // This is the struct containing all state carried with
-//! // the new type. Generally this has to make use of
-//! // interior mutability.
-//! pub struct SimpleObjectPrivate {
-//!     name: RefCell<Option<String>>,
-//!     animal: Cell<Animal>,
-//!     flags: Cell<MyFlags>,
-//! }
+//!     // Static array for defining the properties of the new type.
+//!     static PROPERTIES: [subclass::Property; 3] = [
+//!         subclass::Property("name", |name| {
+//!             glib::ParamSpec::string(
+//!                 name,
+//!                 "Name",
+//!                 "Name of this object",
+//!                 None,
+//!                 glib::ParamFlags::READWRITE,
+//!             )
+//!         }),
+//!         subclass::Property("animal", |name| {
+//!             glib::ParamSpec::enum_(
+//!                 name,
+//!                 "Animal",
+//!                 "Animal",
+//!                 Animal::static_type(),
+//!                 Animal::default() as i32,
+//!                 glib::ParamFlags::READWRITE,
+//!             )
+//!         }),
+//!         subclass::Property("flags", |name| {
+//!             glib::ParamSpec::flags(
+//!                 name,
+//!                 "Flags",
+//!                 "Flags",
+//!                 MyFlags::static_type(),
+//!                 MyFlags::default().bits(),
+//!                 glib::ParamFlags::READWRITE,
+//!             )
+//!         }),
+//!     ];
 //!
-//! // ObjectSubclass is the trait that defines the new type and
-//! // contains all information needed by the GObject type system,
-//! // including the new type's name, parent type, etc.
-//! impl ObjectSubclass for SimpleObjectPrivate {
-//!     // This type name must be unique per process.
-//!     const NAME: &'static str = "SimpleObject";
-//!
-//!     // The parent type this one is inheriting from.
-//!     type ParentType = glib::Object;
-//!
-//!     // The C/FFI instance and class structs. The simple ones
-//!     // are enough in most cases and more is only needed to
-//!     // expose public instance fields to C APIs or to provide
-//!     // new virtual methods for subclasses of this type.
-//!     type Instance = subclass::simple::InstanceStruct<Self>;
-//!     type Class = subclass::simple::ClassStruct<Self>;
-//!
-//!     // This macro defines some boilerplate.
-//!     glib_object_subclass!();
-//!
-//!     // Called right before the first time an instance of the new
-//!     // type is created. Here class specific settings can be performed,
-//!     // including installation of properties and registration of signals
-//!     // for the new type.
-//!     fn class_init(klass: &mut subclass::simple::ClassStruct<Self>) {
-//!         klass.install_properties(&PROPERTIES);
+//!     // This is the struct containing all state carried with
+//!     // the new type. Generally this has to make use of
+//!     // interior mutability.
+//!     pub struct SimpleObject {
+//!         name: RefCell<Option<String>>,
+//!         animal: Cell<Animal>,
+//!         flags: Cell<MyFlags>,
 //!     }
 //!
-//!     // Called every time a new instance is created. This should return
-//!     // a new instance of our type with its basic values.
-//!     fn new() -> Self {
-//!         Self {
-//!             name: RefCell::new(None),
-//!             animal: Cell::new(Animal::default()),
-//!             flags: Cell::new(MyFlags::default()),
+//!     // ObjectSubclass is the trait that defines the new type and
+//!     // contains all information needed by the GObject type system,
+//!     // including the new type's name, parent type, etc.
+//!     impl ObjectSubclass for SimpleObject {
+//!         // This type name must be unique per process.
+//!         const NAME: &'static str = "SimpleObject";
+//!
+//!         // The parent type this one is inheriting from.
+//!         type ParentType = glib::Object;
+//!
+//!         // The C/FFI instance and class structs. The simple ones
+//!         // are enough in most cases and more is only needed to
+//!         // expose public instance fields to C APIs or to provide
+//!         // new virtual methods for subclasses of this type.
+//!         type Instance = subclass::simple::InstanceStruct<Self>;
+//!         type Class = subclass::simple::ClassStruct<Self>;
+//!
+//!         // This macro defines some boilerplate.
+//!         glib_object_subclass!();
+//!
+//!         // Called right before the first time an instance of the new
+//!         // type is created. Here class specific settings can be performed,
+//!         // including installation of properties and registration of signals
+//!         // for the new type.
+//!         fn class_init(klass: &mut subclass::simple::ClassStruct<Self>) {
+//!             klass.install_properties(&PROPERTIES);
+//!         }
+//!
+//!         // Called every time a new instance is created. This should return
+//!         // a new instance of our type with its basic values.
+//!         fn new() -> Self {
+//!             Self {
+//!                 name: RefCell::new(None),
+//!                 animal: Cell::new(Animal::default()),
+//!                 flags: Cell::new(MyFlags::default()),
+//!             }
 //!         }
 //!     }
-//! }
 //!
-//! // Trait that is used to override virtual methods of glib::Object.
-//! impl ObjectImpl for SimpleObjectPrivate {
-//!     // Called whenever a property is set on this instance. The id
-//!     // is the same as the index of the property in the PROPERTIES array.
-//!     fn set_property(&self, _obj: &glib::Object, id: usize, value: &glib::Value) {
-//!         let prop = &PROPERTIES[id];
+//!     // Trait that is used to override virtual methods of glib::Object.
+//!     impl ObjectImpl for SimpleObject {
+//!         // Called whenever a property is set on this instance. The id
+//!         // is the same as the index of the property in the PROPERTIES array.
+//!         fn set_property(&self, _obj: &glib::Object, id: usize, value: &glib::Value) {
+//!             let prop = &PROPERTIES[id];
 //!
-//!         match *prop {
-//!             subclass::Property("name", ..) => {
+//!             match *prop {
+//!                 subclass::Property("name", ..) => {
 //!                 let name = value
-//!                     .get()
-//!                     .expect("type conformity checked by `Object::set_property`");
-//!                 self.name.replace(name);
-//!             },
-//!             subclass::Property("animal", ..) => {
-//!                 let animal = value
-//!                     .get()
-//!                     .expect("type conformity checked by `Object::set_property`");
-//!                 self.animal.replace(animal.unwrap());
-//!             },
-//!             subclass::Property("flags", ..) => {
-//!                 let flags = value
-//!                     .get()
-//!                     .expect("type conformity checked by `Object::set_property`");
-//!                 self.flags.replace(flags.unwrap());
-//!             },
-//!             _ => unimplemented!(),
+//!                         .get()
+//!                         .expect("type conformity checked by `Object::set_property`");
+//!                     self.name.replace(name);
+//!                 },
+//!                 subclass::Property("animal", ..) => {
+//!                     let animal = value
+//!                         .get()
+//!                         .expect("type conformity checked by `Object::set_property`");
+//!                     self.animal.replace(animal.unwrap());
+//!                 },
+//!                 subclass::Property("flags", ..) => {
+//!                     let flags = value
+//!                         .get()
+//!                         .expect("type conformity checked by `Object::set_property`");
+//!                     self.flags.replace(flags.unwrap());
+//!                 },
+//!                 _ => unimplemented!(),
+//!             }
 //!         }
-//!     }
 //!
-//!     // Called whenever a property is retrieved from this instance. The id
-//!     // is the same as the index of the property in the PROPERTIES array.
-//!     fn get_property(&self, _obj: &glib::Object, id: usize) -> Result<glib::Value, ()> {
-//!         let prop = &PROPERTIES[id];
+//!         // Called whenever a property is retrieved from this instance. The id
+//!         // is the same as the index of the property in the PROPERTIES array.
+//!         fn get_property(&self, _obj: &glib::Object, id: usize) -> Result<glib::Value, ()> {
+//!             let prop = &PROPERTIES[id];
 //!
-//!         match *prop {
-//!             subclass::Property("name", ..) => Ok(self.name.borrow().to_value()),
-//!             subclass::Property("animal", ..) => Ok(self.animal.get().to_value()),
-//!             subclass::Property("flags", ..) => Ok(self.flags.get().to_value()),
-//!             _ => unimplemented!(),
+//!             match *prop {
+//!                 subclass::Property("name", ..) => Ok(self.name.borrow().to_value()),
+//!                 subclass::Property("animal", ..) => Ok(self.animal.get().to_value()),
+//!                 subclass::Property("flags", ..) => Ok(self.flags.get().to_value()),
+//!                 _ => unimplemented!(),
+//!             }
 //!         }
-//!     }
 //!
-//!     // Called right after construction of the instance.
-//!     fn constructed(&self, obj: &glib::Object) {
-//!         // Chain up to the parent type's implementation of this virtual
-//!         // method.
-//!         self.parent_constructed(obj);
+//!         // Called right after construction of the instance.
+//!         fn constructed(&self, obj: &glib::Object) {
+//!                 // Chain up to the parent type's implementation of this virtual
+//!             // method.
+//!             self.parent_constructed(obj);
 //!
-//!         // And here we could do our own initialization.
+//!             // And here we could do our own initialization.
+//!         }
 //!     }
 //! }
 //!
 //! // Optionally, define a wrapper type to make it more ergonomic to use from Rust
 //! glib_wrapper! {
-//!     pub struct SimpleObject(ObjectSubclass<SimpleObjectPrivate, SimpleObjectClass>);
+//!     pub struct SimpleObject(ObjectSubclass<imp::SimpleObject, SimpleObjectClass>);
 //! }
 //!
 //! impl SimpleObject {

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -428,6 +428,47 @@ macro_rules! glib_wrapper {
             @get_type $get_type_expr, @extends [$($extends),+], @implements [$($implements),+]);
     };
 
+    // ObjectSubclass, no parents or interfaces
+    (
+        $(#[$attr:meta])*
+        pub struct $name:ident(ObjectSubclass<$subclass:ty, $rust_class_name:ident>);
+    ) => {
+        use glib::translate::ToGlib;
+        $crate::glib_object_wrapper!(@object [$($attr)*] $name, <$subclass as $crate::subclass::types::ObjectSubclass>::Instance, <$subclass as $crate::subclass::types::ObjectSubclass>::Class, $rust_class_name,
+            @get_type $crate::translate::ToGlib::to_glib(&<$subclass as $crate::subclass::types::ObjectSubclass>::get_type()),
+            @extends [], @implements []);
+    };
+
+    // ObjectSubclass, no parents, interfaces
+    (
+        $(#[$attr:meta])*
+        pub struct $name:ident(ObjectSubclass<$subclass:ty, $rust_class_name:ident>) @implements $($implements:path),+;
+    ) => {
+        $crate::glib_object_wrapper!(@object [$($attr)*] $name, <$subclass as $crate::subclass::types::ObjectSubclass>::Instance, <$subclass as $crate::subclass::types::ObjectSubclass>::Class, $rust_class_name,
+            @get_type $crate::translate::ToGlib::to_glib(&<$subclass as $crate::subclass::types::ObjectSubclass>::get_type()),
+            @extends [], @implements [$($implements),+]);
+    };
+
+    // ObjectSubclass, parents, no interfaces
+    (
+        $(#[$attr:meta])*
+        pub struct $name:ident(ObjectSubclass<$subclass:ty, $rust_class_name:ident>) @extends $($extends:path),+;
+    ) => {
+        $crate::glib_object_wrapper!(@object [$($attr)*] $name, <$subclass as $crate::subclass::types::ObjectSubclass>::Instance, <$subclass as $crate::subclass::types::ObjectSubclass>::Class, $rust_class_name,
+            @get_type $crate::translate::ToGlib::to_glib(&<$subclass as $crate::subclass::types::ObjectSubclass>::get_type()),
+            @extends [$($extends),+], @implements []);
+    };
+
+    // ObjectSubclass, parents and interfaces
+    (
+        $(#[$attr:meta])*
+        pub struct $name:ident(ObjectSubclass<$subclass:ty, $rust_class_name:ident>) @extends $($extends:path),+, @implements $($implements:path),+;
+    ) => {
+        $crate::glib_object_wrapper!(@object [$($attr)*] $name, <$subclass as $crate::subclass::types::ObjectSubclass>::Instance, <$subclass as $crate::subclass::types::ObjectSubclass>::Class, $rust_class_name,
+            @get_type $crate::translate::ToGlib::to_glib(&<$subclass as $crate::subclass::types::ObjectSubclass>::get_type()),
+            @extends [$($extends),+], @implements [$($implements),+]);
+    };
+
     // Interface, no prerequisites
     (
         $(#[$attr:meta])*


### PR DESCRIPTION
This makes it easier to define a wrapper for a type defined in Rust using `ObjectSubclass`. It also updates the `glib::subclass` documentation to use this.

I'm not all that fond of the `glib_wrapper!` macro, and would be happy to see something better, but this seems like a good way to improve subclassing ergonomics for now.

There's certainly more room for improvement in both the API and documentation for subclassing.