### PR TITLE
Remove PhantomData from struct created in glib_object_wrapper!

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -724,7 +724,7 @@ macro_rules! glib_object_wrapper {
         // types. Due to inheritance and up/downcasting we must implement these by pointer or
         // otherwise they would potentially give differeny results for the same object depending on
         // the type we currently know for it
-        #[derive(Clone, Hash, Ord)]
+        #[derive(Clone, Hash, PartialOrd, Ord, PartialEq, Eq, Debug)]
         pub struct $name($crate::object::ObjectRef);
 
         #[doc(hidden)]
@@ -1031,30 +1031,6 @@ macro_rules! glib_object_wrapper {
             fn static_type() -> $crate::types::Type {
                 #[allow(unused_unsafe)]
                 unsafe { $crate::translate::from_glib($get_type_expr) }
-            }
-        }
-
-        impl<T: $crate::object::ObjectType> ::std::cmp::PartialEq<T> for $name {
-            #[inline]
-            fn eq(&self, other: &T) -> bool {
-                $crate::translate::ToGlibPtr::to_glib_none(&self.0).0 == $crate::translate::ToGlibPtr::to_glib_none($crate::object::ObjectType::as_object_ref(other)).0
-            }
-        }
-
-        impl ::std::cmp::Eq for $name { }
-
-        impl<T: $crate::object::ObjectType> ::std::cmp::PartialOrd<T> for $name {
-            #[inline]
-            fn partial_cmp(&self, other: &T) -> Option<::std::cmp::Ordering> {
-                $crate::translate::ToGlibPtr::to_glib_none(&self.0).0.partial_cmp(&$crate::translate::ToGlibPtr::to_glib_none($crate::object::ObjectType::as_object_ref(other)).0)
-            }
-        }
-
-        impl ::std::fmt::Debug for $name {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                f.debug_struct(stringify!($name))
-                    .field("inner", &self.0)
-                    .finish()
             }
         }
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -725,7 +725,7 @@ macro_rules! glib_object_wrapper {
         // otherwise they would potentially give differeny results for the same object depending on
         // the type we currently know for it
         #[derive(Clone, Hash, Ord)]
-        pub struct $name($crate::object::ObjectRef, ::std::marker::PhantomData<$ffi_name>);
+        pub struct $name($crate::object::ObjectRef);
 
         #[doc(hidden)]
         impl Into<$crate::object::ObjectRef> for $name {
@@ -738,7 +738,7 @@ macro_rules! glib_object_wrapper {
         impl $crate::object::UnsafeFrom<$crate::object::ObjectRef> for $name {
             #[allow(clippy::missing_safety_doc)]
             unsafe fn unsafe_from(t: $crate::object::ObjectRef) -> Self {
-                $name(t, ::std::marker::PhantomData)
+                $name(t)
             }
         }
 
@@ -881,7 +881,7 @@ macro_rules! glib_object_wrapper {
             #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_none(ptr: *mut $ffi_name) -> Self {
                 debug_assert!($crate::types::instance_of::<Self>(ptr as *const _));
-                $name($crate::translate::from_glib_none(ptr as *mut _), ::std::marker::PhantomData)
+                $name($crate::translate::from_glib_none(ptr as *mut _))
             }
         }
 
@@ -892,7 +892,7 @@ macro_rules! glib_object_wrapper {
             #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_none(ptr: *const $ffi_name) -> Self {
                 debug_assert!($crate::types::instance_of::<Self>(ptr as *const _));
-                $name($crate::translate::from_glib_none(ptr as *mut _), ::std::marker::PhantomData)
+                $name($crate::translate::from_glib_none(ptr as *mut _))
             }
         }
 
@@ -903,7 +903,7 @@ macro_rules! glib_object_wrapper {
             #[allow(clippy::missing_safety_doc)]
             unsafe fn from_glib_full(ptr: *mut $ffi_name) -> Self {
                 debug_assert!($crate::types::instance_of::<Self>(ptr as *const _));
-                $name($crate::translate::from_glib_full(ptr as *mut _), ::std::marker::PhantomData)
+                $name($crate::translate::from_glib_full(ptr as *mut _))
             }
         }
 
@@ -916,8 +916,7 @@ macro_rules! glib_object_wrapper {
                 debug_assert!($crate::types::instance_of::<Self>(ptr as *const _));
                 $crate::translate::Borrowed::new(
                     $name(
-                        $crate::translate::from_glib_borrow::<_, $crate::object::ObjectRef>(ptr as *mut _).into_inner(),
-                        ::std::marker::PhantomData,
+                        $crate::translate::from_glib_borrow::<_, $crate::object::ObjectRef>(ptr as *mut _).into_inner()
                     )
                 )
             }

--- a/src/value.rs
+++ b/src/value.rs
@@ -133,8 +133,8 @@ impl error::Error for GetError {}
 ///
 /// See the [module documentation](index.html) for more details.
 // TODO: Should use impl !Send for Value {} once stable
-#[repr(C)]
-pub struct Value(pub(crate) gobject_sys::GValue, PhantomData<*const c_void>);
+#[repr(transparent)]
+pub struct Value(pub(crate) gobject_sys::GValue);
 
 impl Value {
     /// Creates a new `Value` that is initialized with `type_`


### PR DESCRIPTION
I don't believe these any reason to use `PhantomData` in a struct like this that isn't generic.

`glib` itself, at least, still compiles and passes tests with this simply removed.