### PR TITLE
Panic if ObjectSubclass::get_instance() is called on a finalizing object

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -562,6 +562,7 @@ impl FromGlibPtrNone<*mut GObject> for ObjectRef {
     #[inline]
     unsafe fn from_glib_none(ptr: *mut GObject) -> Self {
         assert!(!ptr.is_null());
+        assert_ne!((*ptr).ref_count, 0);
 
         // Attention: This takes ownership of floating references!
         ObjectRef {
@@ -584,6 +585,7 @@ impl FromGlibPtrFull<*mut GObject> for ObjectRef {
     #[inline]
     unsafe fn from_glib_full(ptr: *mut GObject) -> Self {
         assert!(!ptr.is_null());
+        assert_ne!((*ptr).ref_count, 0);
 
         ObjectRef {
             inner: ptr::NonNull::new_unchecked(ptr),
@@ -596,6 +598,7 @@ impl FromGlibPtrBorrow<*mut GObject> for ObjectRef {
     #[inline]
     unsafe fn from_glib_borrow(ptr: *mut GObject) -> Borrowed<Self> {
         assert!(!ptr.is_null());
+        assert_ne!((*ptr).ref_count, 0);
 
         Borrowed::new(ObjectRef {
             inner: ptr::NonNull::new_unchecked(ptr),
@@ -1043,6 +1046,7 @@ macro_rules! glib_object_wrapper {
                 // Attention: Don't use from_glib_none() here because we don't want to steal any
                 // floating references that might be owned by someone else.
                 if !obj.is_null() {
+                    assert_ne!((*obj).ref_count, 0);
                     $crate::gobject_sys::g_object_ref(obj);
                 }
 

--- a/src/subclass/types.rs
+++ b/src/subclass/types.rs
@@ -302,6 +302,11 @@ pub trait ObjectSubclass: Sized + 'static {
             let ptr = ptr.offset(offset);
             let ptr = ptr as *mut u8 as *mut <Self::ParentType as ObjectType>::GlibType;
 
+            // The object might just be finalized, and in that case it's unsafe to access
+            // it and use any API on it. This can only happen from inside the Drop impl
+            // of Self.
+            assert_ne!((*(ptr as *mut gobject_sys::GObject)).ref_count, 0);
+
             // Don't steal floating reference here via from_glib_none() but
             // preserve it if needed by reffing manually.
             gobject_sys::g_object_ref(ptr as *mut gobject_sys::GObject);

--- a/src/value.rs
+++ b/src/value.rs
@@ -871,7 +871,7 @@ pub trait FromValueOptional<'a>: StaticType + Sized {
     ///
     /// The caller is responsible for ensuring the given `Value` is of a suitable
     /// type for this conversion.
-    unsafe fn from_value_optional(&'a Value) -> Option<Self>;
+    unsafe fn from_value_optional(value: &'a Value) -> Option<Self>;
 }
 
 /// Extracts a value.
@@ -882,7 +882,7 @@ pub trait FromValue<'a>: FromValueOptional<'a> {
     ///
     /// The caller is responsible for ensuring the given `Value` is of a suitable
     /// type for this conversion.
-    unsafe fn from_value(&'a Value) -> Self;
+    unsafe fn from_value(value: &'a Value) -> Self;
 }
 
 /// Sets a value.
@@ -893,7 +893,7 @@ pub trait SetValueOptional: SetValue {
     ///
     /// The caller is responsible for ensuring the given `Value` is of a suitable
     /// type for this conversion.
-    unsafe fn set_value_optional(&mut Value, Option<&Self>);
+    unsafe fn set_value_optional(value: &mut Value, new_value: Option<&Self>);
 }
 
 /// Sets a value.
@@ -902,7 +902,7 @@ pub trait SetValue: StaticType {
     ///
     /// The caller is responsible for ensuring the given `Value` is of a suitable
     /// type for this conversion.
-    unsafe fn set_value(&mut Value, &Self);
+    unsafe fn set_value(value: &mut Value, new_value: &Self);
 }
 
 impl<'a> FromValueOptional<'a> for String {


### PR DESCRIPTION
The object might just be finalized, and in that case it's unsafe to access it and use any API on it. This can only happen from inside the Drop impl of Self.